### PR TITLE
read minor version of client during Login request

### DIFF
--- a/src/messages.d
+++ b/src/messages.d
@@ -133,17 +133,25 @@ class Message
 
 class ULogin : Message
 {		// New login
-	string name;	// user name
-	string pass;	// user password
-	uint   vers;	// client version
+	string username;		// user name
+	string password;		// user password
+	uint   major_version;	// client version
+	string hash;			// MD5 hash of username + password
+	uint   minor_version;	// client minor version
 
 	this(ubyte[] in_buf)
 	{
 		super(in_buf);
 
-		name = reads();
-		pass = reads();
-		vers = readi();
+		username = reads();
+		password = reads();
+		major_version = readi();
+
+		if (major_version >= 155) {
+			// Older clients would not send these
+			hash = reads();
+			minor_version = readi();
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #4

+ Added: Read the MD5 `hash` _(not implemented)_ and `minv` _(minor?)_ parameters of the `ULogin` (code `1`) request
+ Added: Implement `minv` value in `User` class variable `minor_version`
+ Changed: Renamed `User` class variable `cversion` to `major_version`
+ Added: Append `minor_version` in "User logging in" console message
+ Added: Append `minor_version` in `get_motd()` function, move call after `add_user()` to get data from `user_list`
+ Added: Append `minor_version` in `info` admin command

This value is required to filter certain client versions or perhaps alter the server's behaviour depending upon which features are supported by a particular peer's client (for example, forward distributed search requests to `160.2` clients but not for `160.1`).