### PR TITLE
db.d: simplify config storage

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -22,36 +22,23 @@ class Sdb
 
 	const string users_table  = "users";
 	const string admins_table = "admins";
-	const string conf_table   = "conf";
+	const string config_table   = "config";
 
-	const string users_table_format  = "CREATE TABLE %s(username TEXT PRIMARY KEY, password TEXT, speed INTEGER, ulnum INTEGER, files INTEGER, folders INTEGER, banned INTEGER, privileges INTEGER) WITHOUT ROWID;";
-	const string admins_table_format = "CREATE TABLE %s(username TEXT PRIMARY KEY, level INTEGER) WITHOUT ROWID;";
-	const string conf_table_format   = "CREATE TABLE %s(port INTEGER, max_users INTEGER, motd TEXT);";
+	const string users_table_format  = "CREATE TABLE IF NOT EXISTS %s(username TEXT PRIMARY KEY, password TEXT, speed INTEGER, ulnum INTEGER, files INTEGER, folders INTEGER, banned INTEGER, privileges INTEGER) WITHOUT ROWID;";
+	const string admins_table_format = "CREATE TABLE IF NOT EXISTS %s(username TEXT PRIMARY KEY, level INTEGER) WITHOUT ROWID;";
+	const string config_table_format   = "CREATE TABLE IF NOT EXISTS %s(option TEXT PRIMARY KEY, value) WITHOUT ROWID;";
 
 	this(string file, bool update = false)
 	{
-		string default_conf_format = "INSERT INTO %%s(port, max_users, motd) VALUES(%d, %d, 'Soulfind %s');".format(port, max_users, VERSION);
-		if (!exists(file) || !isFile(file)) {
-			open_db(file);
-			if (!exists(file) || !isFile(file)) {
-				throw new Exception("Cannot create database file " ~ file);
-				return;
-			}
-			query(format(users_table_format,  users_table));
-			query(format(admins_table_format, admins_table));
-			query(format(conf_table_format,   conf_table));
-			query(format(default_conf_format, conf_table));
-		}
-		else {
-			open_db(file);
+		open_db(file);
 
-			string[][] res = query(format("SELECT sql FROM sqlite_master WHERE name = '%s';", conf_table));
-			if (res[0][0] != conf_table_format[0 .. $-1].format(conf_table)) {
-				write("Configuration needs to be updated... ");
-				update_conf_table(res[0][0], default_conf_format[0 .. $-1]);
-				writeln("updated.");
-			}
+		if (!exists(file) || !isFile(file)) {
+			throw new Exception("Cannot create database file %s".format(file));
+			return;
 		}
+		query(format(users_table_format,  users_table));
+		query(format(admins_table_format, admins_table));
+		init_config();
 	}
 
 	@trusted
@@ -60,43 +47,16 @@ class Sdb
 		sqlite3_open(file.toStringz(), &db);
 	}
 
-	// argh, I never realised that ALTER TABLE was so useful
-	void update_conf_table(string creation_string, string default_conf_format)
-	{
-		string old_fields = join(parse_db_format(creation_string), ",");
-		
-		query(format(conf_table_format, "tmp_conf"));		// create a temp table
-		query(format(default_conf_format, "tmp_conf"));		// fill it with the default values
-		query(format("INSERT INTO tmp_conf(%s) SELECT %s FROM %s;", old_fields, old_fields, conf_table)); // fetch the already existing values into the temp table
-		query(format("DROP TABLE %s;", conf_table));		// delete the old configuration table
-		query(format(conf_table_format, conf_table));		// re-create it, with the new format now
-		query(format("INSERT INTO %s SELECT * FROM tmp_conf;", conf_table));	// fetch the temp table values into the new configuration table
-		query(format("DROP TABLE tmp_conf"));			// and finally drop the temp table...
-	}
-	
-	// my eyes are bleeding !
-	string[] parse_db_format(string f)
-	{ // format is like "CREATE TABLE conf(port integer, max_users integer)"
-		string[] res = split(f);
-		res = res[3 .. $];       // remove "CREATE TABLE conf"
-		res[0] = res[0][1 .. $]; // remove '('
-
-		string[] ret;
-		ret.length = res.length/2;
-		for(uint i = 0 ; i < ret.length ; i++) ret[i] = res[i*2];
-		return ret;
-	}
-	
 	void add_admin(string username, uint level = 0)
 	{
 		this.query(format("REPLACE INTO %s(username, level) VALUES('%s', %d);", admins_table, escape(username), level));
 	}
-	
+
 	void del_admin(string username)
 	{
 		this.query(format("DELETE FROM %s WHERE username = '%s';", admins_table, escape(username)));
 	}
-	
+
 	string[] get_admins()
 	{
 		string[][] res = this.query(format("SELECT username FROM %s;", admins_table));
@@ -105,26 +65,39 @@ class Sdb
 		foreach (string[] record ; res) ret ~= record[0];
 		return ret;
 	}
-	
-	void conf_set_field(string field, uint value)
+
+	void init_config()
 	{
-		this.query(format("UPDATE %s SET '%s' = %d;", conf_table, field, value));
+		query(config_table_format.format(config_table));
+
+		init_config_option("port", port);
+		init_config_option("max_users", max_users);
+		init_config_option("motd", "Soulfind %version%");
 	}
-	
-	void conf_set_field(string field, string value)
+
+	void init_config_option(string option, string value)
 	{
-		this.query(format("UPDATE %s SET '%s' = '%s';", conf_table, field, escape(value)));
+		query("INSERT OR IGNORE INTO %s(option, value) VALUES('%s', '%s');".format(config_table, option, escape(value)));
 	}
-	
-	uint conf_get_int(string field)
+
+	void init_config_option(string option, uint value)
 	{
-		string[][] res = this.query(format("SELECT %s FROM %s;", field, conf_table));
-		return to!uint(res[0][0]);
+		query("INSERT OR IGNORE INTO %s(option, value) VALUES('%s', %d);".format(config_table, option, value));
 	}
-	
-	string conf_get_str(string field)
+
+	void set_config_value(string option, string value)
 	{
-		string[][] res = this.query(format("SELECT %s FROM %s;", field, conf_table));
+		query("REPLACE INTO %s(option, value) VALUES('%s', '%s');".format(config_table, option, escape(value)));
+	}
+
+	void set_config_value(string option, uint value)
+	{
+		query("REPLACE INTO %s(option, value) VALUES('%s', %d);".format(config_table, option, value));
+	}
+
+	string get_config_value(string option)
+	{
+		string[][] res = query("SELECT value FROM %s WHERE option = '%s';".format(config_table, option));
 		return res[0][0];
 	}
 
@@ -134,7 +107,7 @@ class Sdb
 		string[][] res = this.query(query);
 		return atoi(res[0][0]);
 	}
-	
+
 	uint nb_banned_users()
 	{
 		string query = "SELECT COUNT(username) FROM %s WHERE banned = 1;".format(users_table);
@@ -173,19 +146,19 @@ class Sdb
 		foreach (string[] record ; res) ret ~= record[0];
 		return ret;
 	}
-	
+
 	bool user_exists(string username)
 	{
 		string[][] res = this.query(format("SELECT username FROM %s WHERE username = '%s';", users_table, escape(username)));
 		return res.length > 0;
 	}
-	
+
 	string get_pass(string username)
 	{
 		string[][] res = this.query(format("SELECT password FROM %s WHERE username = '%s';", users_table, escape(username)));
 		return res[0][0];
 	}
-	
+
 	void add_user(string username, string password)
 	{
 		string query = "INSERT INTO %s(username, password) VALUES('%s', '%s');".format(
@@ -194,7 +167,7 @@ class Sdb
 		this.query(query);
 		debug(db) writeln(query);
 	}
-	
+
 	bool is_banned(string username)
 	{
 		string query = "SELECT banned FROM %s WHERE username = '%s';".format(
@@ -227,7 +200,7 @@ class Sdb
 		}
 		return false;
 	}
-	
+
 	bool get_user(string username, string password, out uint speed, out uint upload_number, out uint shared_files, out uint shared_folders, out uint privileges)
 	{
 		debug(db) writeln("DB: Requested ", username, "'s info...");
@@ -292,7 +265,7 @@ class Sdb
 	{
 		if (str == "")
 			return 0;
-		
+
 		try {
 			uint i = to!uint(str);
 			return i;

--- a/src/server.d
+++ b/src/server.d
@@ -586,10 +586,10 @@ class Server
 
 	private void config(bool reload = false)
 	{
-		motd = db.conf_get_str("motd");
+		motd = db.get_config_value("motd");
 		if (!reload) {
-			port = cast(ushort)db.conf_get_int("port");
-			max_users = db.conf_get_int("max_users");
+			port = db.get_config_value("port").to!ushort;
+			max_users = db.get_config_value("max_users").to!uint;
 		}
 
 		foreach (admin ; db.get_admins()) {
@@ -618,7 +618,7 @@ class Server
 			return false;
 		}
 		foreach (dchar c ; text) if (!isPrintable(c)) {
-			// non-ASCII control chars, etc 
+			// non-ASCII control chars, etc
 			return false;
 		}
 		if (text.length == 1 && isPunctuation(text.to!dchar)) {

--- a/src/soulsetup.d
+++ b/src/soulsetup.d
@@ -21,7 +21,7 @@ Sdb sdb;
 void main(string[] args)
 {
 	string db_file = default_db_file;
-	
+
 	if (args.length > 1) {
 		if (args[1] == "--help" || args[1] == "-h") {
 			writeln("Usage: ", args[0], " [database_file]");
@@ -48,7 +48,7 @@ string input()
 void main_menu()
 {
 	auto menu = new Menu("Soulfind %s configuration".format(VERSION));
-	
+
 	menu.add("0", "Admins",            &admins);
 	menu.add("1", "Listen port",       &listen_port);
 	menu.add("2", "Max users allowed", &max_users);
@@ -56,7 +56,7 @@ void main_menu()
 	menu.add("4", "Banned users",      &banned_users);
 	menu.add("i", "Server info",       &info);
 	menu.add("q", "Exit",              &exit);
-	
+
 	menu.show();
 }
 
@@ -68,7 +68,7 @@ void exit()
 void admins()
 {
 	auto menu = new Menu("Admins");
-	
+
 	menu.add("1", "Add an admin",    &add_admin);
 	menu.add("2", "Remove an admin", &del_admin);
 	menu.add("3", "List admins",     &list_admins);
@@ -106,12 +106,12 @@ void list_admins()
 
 	admins();
 }
-	
+
 
 void listen_port()
 {
 	uint port;
-	try {port = sdb.conf_get_int("port");} catch (ConvException) {}
+	try {port = sdb.get_config_value("port").to!ushort;} catch (ConvException) {}
 
 	auto menu = new Menu(format("Listen port : %d", port));
 	menu.add("1", "Change listen port", &set_listen_port);
@@ -133,14 +133,14 @@ void set_listen_port()
 		return;
 	}
 
-	sdb.conf_set_field("port", port);
+	sdb.set_config_value("port", port);
 	listen_port();
 }
 
 void max_users()
 {
 	uint max_users;
-	try {max_users = sdb.conf_get_int("max_users");} catch (ConvException) {}
+	try {max_users = sdb.get_config_value("max_users").to!uint;} catch (ConvException) {}
 
 	auto menu = new Menu(format("Max users allowed : %d", max_users));
 	menu.add("1", "Change max users", &set_max_users);
@@ -164,7 +164,7 @@ void set_max_users()
 		return;
 	}
 
-	sdb.conf_set_field("max_users", num_users);
+	sdb.set_config_value("max_users", num_users);
 	max_users();
 }
 
@@ -172,7 +172,7 @@ void motd()
 {
 	auto menu = new Menu(
 		format("Current message of the day :\n--\n%s\n--\n",
-			sdb.conf_get_str("motd"))
+			sdb.get_config_value("motd"))
 	);
 	menu.add("1", "Change MOTD", &set_motd);
 	menu.add("q", "Return",      &main_menu);
@@ -202,7 +202,7 @@ void set_motd()
 	}
 	while(true);
 
-	sdb.conf_set_field("motd", MOTD);
+	sdb.set_config_value("motd", MOTD);
 	motd();
 }
 
@@ -222,7 +222,7 @@ void info()
 void banned_users()
 {
 	auto menu = new Menu("Banned users");
-	
+
 	menu.add("1", "Ban an user",       &ban_user);
 	menu.add("2", "Unban an user",     &unban_user);
 	menu.add("3", "List banned users", &list_banned);
@@ -267,12 +267,12 @@ class Menu
 	string info;
 	string[string]           entries;
 	void function()[string] actions;
-	
+
 	this(string title)
 	{
 		this.title = title;
 	}
-	
+
 	void add(string index, string entry, void function() @safe action)
 	{
 		entries[index] = entry;
@@ -291,7 +291,7 @@ class Menu
 	{
 		writeln(format( "\n%s\n", title));
 		if (info.length > 0) writeln(format("%s\n", info));
-		
+
 		foreach (index ; sorted_entry_indexes)
 			writeln(format("%s. %s", index, entries[index]));
 


### PR DESCRIPTION
Instead of having to deal with adding new columns for new options in the future, use a single row per config option.