### PR TITLE
server.d: username and roomname character set length limits

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -573,7 +573,7 @@ class User
 
 			case JoinRoom:
 				auto msg = new UJoinRoom(msg_buf);
-				if (server.check_string(msg.room))
+				if (server.check_name(msg.room))
 					Room.join_room(msg.room, this);
 				break;
 
@@ -902,6 +902,10 @@ class User
 
 	void exit()
 	{
+		if (status == Status.offline) {
+			writeln("User " ~ red, username, black ~ " denied.");
+			return;
+		}
 		update_privileges();
 		foreach (room ; joined_rooms) room.leave(this);
 		Room.remove_global_room_user(username);


### PR DESCRIPTION
Is is a bad idea for enormous strings to be primary keys in a WITHOUT ROWID table, it works best if keys are < 50 bytes or so. This PR aims to avoid a potential performance issue during lookups whilst also being compliant with the protocol.

- Changed: Maximum new username length from 1,000,000,000 (a thousand million) characters to `30` (thirty)
- Changed: Maximum roomname length to `24`
- Changed: Validate username and roomname input strings as [printable ASCII](https://dlang.org/library/std/ascii/is_printable.html) instead of UTF
- Added: Reject usernames and roomnames containing `"  "` (double-spaces), with possiblity for excluding other strings
- Added: Reject names that are only a [punctuation](https://dlang.org/library/std/ascii/is_punctuation.html) symbol (but still allow other single-character alpha/numeric names)
- Added: Minimum of at least 1 character length for user and room names (reject zero-length strings)
- Fixed: Vulnerability where any unregistered alien could execute two non-sanitized database queries before Login

Some other method to properly deal with UTF strings (chat messages, tickers, likes, etc) may have to be devised at a later point, but that will be unrelated to the check_login() Login and JoinRoom protocol apparatus. Hence, the function is renamed.