### PR TITLE
MD5 digest() on ChangePassword and boolean check_pass() on Login

### DIFF
--- a/src/messages.d
+++ b/src/messages.d
@@ -10,8 +10,6 @@ import defines;
 
 import std.bitmanip;
 import std.conv : to;
-//import std.digest : digest, LetterCase, toHexString;
-//import std.digest.md : MD5;
 import std.format : format;
 import std.outbuffer : OutBuffer;
 import std.stdio : writeln;
@@ -136,7 +134,7 @@ class ULogin : Message
 	string username;		// user name
 	string password;		// user password
 	uint   major_version;	// client version
-	string hash;			// MD5 hash of username + password
+	string user_hash;		// MD5 hash of username + password
 	uint   minor_version;	// client minor version
 
 	this(ubyte[] in_buf)
@@ -149,7 +147,7 @@ class ULogin : Message
 
 		if (major_version >= 155) {
 			// Older clients would not send these
-			hash = reads();
+			user_hash = reads();
 			minor_version = readi();
 		}
 	}
@@ -588,7 +586,7 @@ class SLogin : Message
 {	// If the login succeeded send the MOTD and the external IP of the client
 		// if not, send the error message
 	this(bool success, string mesg, uint addr = 0,
-			string pass = null, bool supporter = false)
+			string password_hash = null, bool supporter = false)
 	{
 		super(Login);
 		
@@ -596,8 +594,8 @@ class SLogin : Message
 		writes(mesg);		// server message
 		if (success)
 		{
-			writei(addr);	// external IP address of the client
-			writes(pass);	// digest!MD5(password).toHexString!(LetterCase.lower));
+			writei(addr);			// external IP address of the client
+			writes(password_hash);	// MD5 hash of password
 			writeb(supporter);
 		}
 	}

--- a/src/messages.d
+++ b/src/messages.d
@@ -10,8 +10,8 @@ import defines;
 
 import std.bitmanip;
 import std.conv : to;
-import std.digest : digest, LetterCase, toHexString;
-import std.digest.md : MD5;
+//import std.digest : digest, LetterCase, toHexString;
+//import std.digest.md : MD5;
 import std.format : format;
 import std.outbuffer : OutBuffer;
 import std.stdio : writeln;
@@ -588,7 +588,7 @@ class SLogin : Message
 {	// If the login succeeded send the MOTD and the external IP of the client
 		// if not, send the error message
 	this(bool success, string mesg, uint addr = 0,
-			string password = null, bool supporter = false)
+			string pass = null, bool supporter = false)
 	{
 		super(Login);
 		
@@ -597,7 +597,7 @@ class SLogin : Message
 		if (success)
 		{
 			writei(addr);	// external IP address of the client
-			writes(digest!MD5(password).toHexString!(LetterCase.lower));
+			writes(pass);	// digest!MD5(password).toHexString!(LetterCase.lower));
 			writeb(supporter);
 		}
 	}

--- a/src/server.d
+++ b/src/server.d
@@ -312,6 +312,9 @@ class Server
 
 	void admin_message(User admin, string message)
 	{
+		if (!admin.hash_verified)
+			return;
+
 		auto command = message.split(" ");
 		if (command.length > 0) switch (command[0])
 		{
@@ -489,7 +492,7 @@ class Server
 
 	bool is_admin(string name)
 	{
-			return name in admins ? true : false;
+		return name in admins ? true : false;
 	}
 
 	private void add_admin(string name)
@@ -536,6 +539,7 @@ class Server
 					~ "\n\tclient version: %s"
 					~ "\n\taddress: %s"
 					~ "\n\tadmin: %s"
+					~ "\n\thash verified: %s"
 					~ "\n\tfiles: %s"
 					~ "\n\tdirs: %s"
 					~ "\n\tstatus: %s"
@@ -546,6 +550,7 @@ class Server
 						user.major_version.to!string ~ "." ~ user.minor_version.to!string,
 						user.sock.remoteAddress,
 						is_admin(username),
+						user.hash_verified,
 						user.shared_files,
 						user.shared_folders,
 						user.status,
@@ -645,7 +650,7 @@ class Server
 	}
 
 	bool check_login(string username, string password, uint major_version,
-					 string hash, uint minor_version, out string error)
+					 string user_hash, uint minor_version, out string error)
 	{
 		if (!check_name(username, 30)) {
 			error = "INVALIDUSERNAME";


### PR DESCRIPTION
The plain text password was saved in the database after successfully changing password, resulting in a locked account. This PR fixes that (although all that was actually missing was a encode_password() call in change_password() method), as well as trying out some fundamental security hardening measures which aim to isolate sensitive data away from being stored in memory.

- Fixed: Impossible to login after changing password because plain text was written to database
- Fixed: Incorrect hash sent back to peer's client after successful Login was a hash of the hash instead of just hashing once
- Renamed: Terminology of `pass` is declared to indicate that the value is hashed, as opposed to a plain-text `password` value
- Removed: Don't keep the plain password string hanging around in the User class of the client.d module, there's no need for it
- Removed: Risky function to set any string field with any value is no longer required, since it was only used for password
- Changed: Return only a boolean from the new `check_pass()` function to indicate success or failure during authentication
- Moved: Refactored all password digestion processes into private functions in the db.d module, `this` cannot be an overload
- Added: Require that the password string is non-empty before attempting any database queries during pre-authentication
- Added: Match the concatenated username + password hash and require this for the server admin message interface