### PR TITLE
Rollback version number to 0.5.0-dev

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@
 
 # News
 
+## 0.5.0-dev (Unstable)
+
+ - Relicenced to GNU General Public License v3.0 or later
+ - Validate username and roomname strings as printable ASCII instead of UTF
+ - Substantial breaking changes, including a new database schema, may require
+   a totally fresh install from time to time. Data loss is to be expected.
+
+
 ## 0.4.8
 
  - Updated for DMD 0.155

--- a/README.md
+++ b/README.md
@@ -74,5 +74,6 @@ People who have contributed to Soulfind:
 
  - seeschloss (creator)
  - mathiascode
+ - slook
 
 © 2005–2024 Soulfind Contributors

--- a/src/defines.d
+++ b/src/defines.d
@@ -6,7 +6,7 @@
 module defines;
 @safe:
 
-const string VERSION		= "1.0.0-dev";
+const string VERSION		= "0.5.0-dev";
 const string default_db_file	= "soulfind.db";
 const uint port			= 2242;
 const uint max_users		= 65535;


### PR DESCRIPTION
There isn't going to be any sort of major version release, since this is a research and development effort only, it's likely to remain in alpha indefinitely, so the version ought to remain minor in order to make this clear.