### PR TITLE
client.d: allow user to change password

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -103,12 +103,6 @@ class User
 		server.db.user_update_field(username, "folders", shared_folders);
 	}
 
-	private void change_password(string new_password)
-	{
-		password = new_password;
-		server.db.user_update_field(username, "password", password);
-	}
-
 	// privileges
 	private uint		privileges;			// in seconds
 	private MonoTime	last_priv_check;
@@ -821,8 +815,11 @@ class User
 
 			case ChangePassword:
 				auto msg = new UChangePassword(msg_buf);
+				password = msg.password;
 
-				change_password(msg.password);
+				server.db.user_update_field(
+					username, "password", server.encode_password(password)
+				);
 				send_message(new SChangePassword(password));
 				break;
 

--- a/src/server.d
+++ b/src/server.d
@@ -615,7 +615,7 @@ class Server
 		return dur!"seconds"(uptime.total!"seconds").toString;
 	}
 
-	private string encode_password(string pass)
+	string encode_password(string pass)
 	{
 		ubyte[16] digest = md5Of(pass);
 		string s;


### PR DESCRIPTION
- Fixed: Impossible to login after changing password because plain-text was written to database

This is just a quick fix to get it working for now, a more robust method can be implemented in future.