### PR TITLE
Login encode_password hash in get_user

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -869,7 +869,7 @@ class User
 	private void login(ULogin msg)
 	{
 		username = msg.username;
-		password = msg.password;
+		password = server.encode_password(msg.password);
 		major_version = msg.major_version;
 		minor_version = msg.minor_version;
 

--- a/src/db.d
+++ b/src/db.d
@@ -223,20 +223,19 @@ class Sdb
 		return false;
 	}
 	
-	bool get_user(string username, out string password, out uint speed, out uint upload_number, out uint shared_files, out uint shared_folders, out uint privileges)
+	bool get_user(string username, string password, out uint speed, out uint upload_number, out uint shared_files, out uint shared_folders, out uint privileges)
 	{
 		debug(db) writeln("DB: Requested ", username, "'s info...");
-		string query = format("SELECT password,speed,ulnum,files,folders,privileges FROM %s WHERE username = '%s';", users_table, escape(username));
+		string query = format("SELECT speed,ulnum,files,folders,privileges FROM %s WHERE username = '%s' AND password = '%s';", users_table, escape(username), escape(password));
 		string[][] res = this.query(query);
 		if (res.length > 0) {
 			string[] u      = res[0];
 
-			password        = u[0];
-			speed           = atoi(u[1]);
-			upload_number   = atoi(u[2]);
-			shared_files    = atoi(u[3]);
-			shared_folders  = atoi(u[4]);
-			privileges      = atoi(u[5]);
+			speed           = atoi(u[0]);
+			upload_number   = atoi(u[1]);
+			shared_files    = atoi(u[2]);
+			shared_folders  = atoi(u[3]);
+			privileges      = atoi(u[4]);
 			return true;
 		}
 		return false;

--- a/src/messages.d
+++ b/src/messages.d
@@ -10,8 +10,6 @@ import defines;
 
 import std.bitmanip;
 import std.conv : to;
-import std.digest : digest, LetterCase, toHexString;
-import std.digest.md : MD5;
 import std.format : format;
 import std.outbuffer : OutBuffer;
 import std.stdio : writeln;
@@ -594,7 +592,7 @@ class SLogin : Message
 		if (success)
 		{
 			writei(addr);	// external IP address of the client
-			writes(digest!MD5(password).toHexString!(LetterCase.lower));
+			writes(password);
 			writeb(supporter);
 		}
 	}


### PR DESCRIPTION
- Fixed: Incorrect hash sent back to peer's client after successful Login was a hash of the hash instead of just hashing once
- Changed: Keep the hash instead of the plain `password` string in the User class of the client.d module