### PR TITLE
defines.d: bright white background and bold text ♥

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -308,7 +308,7 @@ class User
 			return;
 
 		debug (msg) write(
-			"Sending message ", blue, message_name[msg.code], black,
+			"Sending message ", blue, message_name[msg.code], norm,
 			" (code ", msg.code, ") to "
 		);
 		foreach (user ; watched_by) {
@@ -377,7 +377,7 @@ class User
 		msg_size_buf.clear();
 
 		debug (msg) writeln(
-			"Sending message ", blue, message_name[msg.code], black,
+			"Sending message ", blue, message_name[msg.code], norm,
 			" (code ", msg.code, ") (", msg_buf.length, " bytes) to ", username
 		);
 	}
@@ -419,8 +419,8 @@ class User
 		in_buf = in_buf[in_msg_size .. $];
 
 		debug (msg) writeln(
-			"Received message ", blue, message_name[code], black, " (code ",
-			code, black, ") (", in_msg_size, " bytes) from ", username
+			"Received message ", blue, message_name[code], norm, " (code ",
+			code, norm, ") (", in_msg_size, " bytes) from ", username
 		);
 
 		in_msg_size = -1;
@@ -442,7 +442,7 @@ class User
 					should_quit = true;
 
 					writeln(username, ": Impossible to login (", error, ")");
-					writeln("User ", red, username, black, " denied.");
+					writeln("User ", red, username, norm, " denied.");
 					send_message(new SLogin(false, error));
 					return;
 				}
@@ -456,7 +456,7 @@ class User
 				}
 
 				writeln(
-					blue, msg.username, black, ", version ",
+					blue, msg.username, norm, ", version ",
 					msg.major_version, ".", msg.minor_version
 				);
 				login(msg);
@@ -853,8 +853,8 @@ class User
 			default:
 				debug (msg) {
 					write(
-						red, "Unimplemented message", black, " from user ",
-						blue, username, black, ", code ", red, code, black,
+						red, "Unimplemented message", norm, " from user ",
+						blue, username, norm, ", code ", red, code, norm,
 						" and length ", msg_buf.length, "\n> "
 					);
 					writeln(msg_buf);
@@ -908,6 +908,6 @@ class User
 		Room.remove_global_room_user(username);
 
 		set_status(Status.offline);
-		writeln("User ", blue, username, black, " has quit.");
+		writeln("User ", blue, username, norm, " has quit.");
 	}
 }

--- a/src/defines.d
+++ b/src/defines.d
@@ -14,6 +14,8 @@ const uint max_msg_size		= 16384;
 const string server_user	= "server";
 
 // colours
-const char[] blue      = "\033[01;94m";
-const char[] black     = "\033[0m";
-const char[] red       = "\033[01;91m";
+const char[] norm	= "\033[0m";		// reset to normal
+const char[] bold	= "\033[1m";		// bold intensity
+const char[] bg_w	= "\033[30;107m";	// background white
+const char[] blue	= "\033[01;94m";	// foreground blue
+const char[] red	= "\033[01;91m";	// foreground red

--- a/src/server.d
+++ b/src/server.d
@@ -133,7 +133,11 @@ class Server
 			return 1789;
 		}
 
-		writeln("Process ", thisProcessID, " listening on port ", port);
+		writeln(
+			bg_w, "▌", red, "♥", norm, bg_w, "▐", norm, bold,
+			"Soulfind %s process %s listening on port %s"
+			.format(VERSION ~ norm, thisProcessID, port)
+		);
 
 		auto read_socks = new SocketSet(max_users + 1);
 		auto write_socks = new SocketSet(max_users + 1);
@@ -298,8 +302,8 @@ class Server
 	private void send_to_all(Message msg)
 	{
 		debug (msg) write(
-			"Sending message(", blue,  message_name[msg.code], black,
-			" - code ", blue, msg.code, black, ") to all users"
+			"Sending message(", blue,  message_name[msg.code], norm,
+			" - code ", blue, msg.code, norm, ") to all users"
 		);
 		foreach (user ; users)
 		{


### PR DESCRIPTION
- Added: Show program name and version at startup with red-on-white unicode heart symbol `U+2665` as icon
- Added: Bright white background colour for block-highlighting text (black-on-white by default, or any foreground colour)
- Added: Bright `bold` text
- Renamed: Defined colour `black` to `norm` because it's just whatever normal is depending on the default terminal scheme

Can also specify a background colour and any foreground, for example `bg_w ~ blue` for blue on white. In this case, red-on-white is used on to represent the project's heart icon surrounded with left and right half blocks to make a white square `▌♥▐` ...

![image](https://github.com/user-attachments/assets/9686c8da-dbe6-43f4-80c7-3bdbfbe44cb3)

It is useful to verify at startup that the runtime terminal does support colour and unicode characters on the standard output.