### PR TITLE
Simplify admins

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -606,7 +606,7 @@ class User
 				auto msg = new UMessageUser(msg_buf);
 				auto user = server.get_user(msg.user);
 
-				if (msg.user == server_user && server.is_admin(username)) {
+				if (msg.user == server_user) {
 					server.admin_message(this, msg.message);
 				}
 				else if (user) { // user is connected
@@ -731,7 +731,7 @@ class User
 				break;
 
 			case AdminMessage:
-				if (!server.is_admin(username))
+				if (!server.db.is_admin(username))
 					break;
 
 				auto msg = new UAdminMessage(msg_buf);
@@ -802,7 +802,7 @@ class User
 			case GivePrivileges:
 				auto msg = new UGivePrivileges(msg_buf);
 				auto user = server.get_user(msg.user);
-				auto admin = server.is_admin(msg.user);
+				auto admin = server.db.is_admin(msg.user);
 				if (!user)
 					break;
 				if (msg.time > privileges && !admin)
@@ -876,7 +876,7 @@ class User
 			shared_folders, privileges
 		);
 
-		if (server.is_admin(username)) writeln(username, " is an admin.");
+		if (server.db.is_admin(username)) writeln(username, " is an admin.");
 		server.add_user(this);
 
 		auto motd = server.get_motd(username);

--- a/src/db.d
+++ b/src/db.d
@@ -105,7 +105,15 @@ class Sdb
 		foreach (string[] record ; res) ret ~= record[0];
 		return ret;
 	}
-	
+
+	bool is_admin(string username)
+	{
+		string[][] res = this.query(
+			"SELECT username FROM %s WHERE username = '%s';".format(admins_table, escape(username))
+		);
+		return to!bool(res.length);
+	}
+
 	void conf_set_field(string field, uint value)
 	{
 		this.query(format("UPDATE %s SET '%s' = %d;", conf_table, field, value));

--- a/src/soulsetup.d
+++ b/src/soulsetup.d
@@ -95,14 +95,8 @@ void list_admins()
 {
 	auto names = sdb.get_admins();
 
-	if (!names) {
-		writeln("No admin on this server");
-		admins();
-		return;
-	}
-
-	writeln("\nAdmins :");
-	foreach (admin ; names) writeln(format("- %s", admin));
+	writeln(format("\nAdmins (%d)...", names.length));
+	foreach (name ; names) writeln(format("\t%s", name));
 
 	admins();
 }


### PR DESCRIPTION
The ~previously~ unimplemented `level` field is required because otherwise the server owner cannot create other admins without fear of being deleted. This PR ~implements 3 admin levels~ _abolishes adding and removing admins from the admin chat interface_ in order to mitigate that issue and makes an improvement to setup...

- **Removed: `addadmin` and `deladmin` chat interface commands, only allow administration using soulsetup**
- Removed: `reload` command, since it's not required anymore, instead changes take effect immediately
- Removed: Don't maintain an `admins` list internally, instead refer directly to the `admins` table of the database
- Changed: Use newlines instead of spaces to separate names on the output of the `admins` command
- Changed: Use tabs instead of hyphens to indent names on the output of "List admins" in Soulsetup
- Added: Display count of the number of registered admins in the list outputs.

_PR edited as per below comment, see comment history for description of implement admins level idea._