### PR TITLE
server.d: abbreviated users list response

### DIFF
--- a/src/server.d
+++ b/src/server.d
@@ -294,11 +294,6 @@ class Server
 		}
 	}
 
-	private ulong nb_users()
-	{
-		return user_list.length;
-	}
-
 	private void send_to_all(Message msg)
 	{
 		debug (msg) write(
@@ -325,8 +320,7 @@ class Server
 				admin_pm(
 					admin,
 					"Available commands :\n\n"
-				  ~ "nbusers\n\tNumber of users connected\n\n"
-				  ~ "users\n\tInfo about each connected user\n\n"
+				  ~ "users\n\tList connected users\n\n"
 				  ~ "info <user>\n\tInfo about user <user>\n\n"
 				  ~ "killall\n\tDisconnect all users\n\n"
 				  ~ "kill <user>\n\tDisconnect <user>\n\n"
@@ -373,14 +367,10 @@ class Server
 				user.add_privileges(days * 3600 * 24);
 				break;
 
-			case "nbusers":
-				auto num_users = nb_users;
-				admin_pm(admin, "%d connected users.".format(num_users));
-				break;
-
 			case "users":
-				auto users = show_users();
-				admin_pm(admin, users);
+				string list = "%d connected users.".format(user_list.length);
+				foreach (username, user ; user_list) list ~= "\n\t" ~ username;
+				admin_pm(admin, list);
 				break;
 
 			case "info":
@@ -524,13 +514,6 @@ class Server
 		}
 	}
 
-	private string show_users()
-	{
-		string s;
-		foreach (username, user ; user_list) s ~= show_user(username) ~ "\n";
-		return s;
-	}
-
 	private string show_user(string username)
 	{
 		auto user = get_user(username);
@@ -595,7 +578,7 @@ class Server
 
 		string ret;
 		ret = replace(motd, "%version%", VERSION);
-		ret = replace(ret, "%nbusers%", nb_users.to!string);
+		ret = replace(ret, "%nbusers%", user_list.length.to!string);
 		ret = replace(ret, "%username%", username);
 		ret = replace(ret, "%userversion%", client_version);
 		return ret;


### PR DESCRIPTION
- Removed: `nbusers` command
- Added: Show count of the number of connected users in the response of the `users` command
- Changed: `users` command outputs one single user per line, showing only the username of each user

The verbosity of the full user info for each user would be excessive if there are a large number of users, whereas what is desired here is only the most pertinent information to be displayed in a plain list format.