### PR TITLE
server.d: fix segmentation fault when banning offline user

### DIFF
--- a/src/server.d
+++ b/src/server.d
@@ -578,7 +578,7 @@ class Server
 			return;
 
 		db.user_update_field(username, "banned", 1);
-		get_user(username).quit();
+		kill_user(username);
 	}
 
 	private void unban_user(string username)


### PR DESCRIPTION
- Fixed: Segmentation fault when banning a user who is offline or doesn't exist (`ban` chat interface command)