### PR TITLE
db.d: count_users() with filtering by any numeric field

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -128,25 +128,29 @@ class Sdb
 		return res[0][0];
 	}
 
-	uint nb_users()
+	uint count_users(string filter_field = null, uint min = 1, uint max = -1)
 	{
-		string query = "SELECT COUNT(username) FROM %s;".format(users_table);
-		string[][] res = this.query(query);
-		return atoi(res[0][0]);
-	}
-	
-	uint nb_banned_users()
-	{
-		string query = "SELECT COUNT(username) FROM %s WHERE banned = 1;".format(users_table);
-		string[][] res = this.query(query);
-		return atoi(res[0][0]);
+		if (!filter_field) {
+			return atoi(this.query("SELECT COUNT(1) FROM %s;".format(users_table))[0][0]);
+		}
+		return atoi(this.query("SELECT COUNT(1) FROM %s WHERE %s BETWEEN %d AND %d;".format(
+			users_table, escape(filter_field), min, max))[0][0]
+		);
 	}
 
-	string[] get_banned_usernames()
+	string[] get_usernames(string filter_field = null, uint min = 1, uint max = -1)
 	{
-		string[][] res = this.query("SELECT username FROM %s WHERE banned = 1;".format(users_table));
 		string[] ret;
+		string[][] res;
 
+		if (!filter_field) {
+			res = this.query("SELECT username FROM %s;".format(users_table));  // all rows
+		}
+		else {
+			res = this.query("SELECT username FROM %s WHERE %s BETWEEN %d AND %d;".format(
+				users_table, escape(filter_field), min, max)
+			);
+		}
 		foreach (string[] record ; res) ret ~= record[0];
 		return ret;
 	}
@@ -165,15 +169,6 @@ class Sdb
 		this.query(query);
 	}
 
-	string[] get_all_usernames()
-	{
-		string[][] res = this.query("SELECT username FROM %s;".format(users_table));
-		string[] ret;
-
-		foreach (string[] record ; res) ret ~= record[0];
-		return ret;
-	}
-	
 	bool user_exists(string username)
 	{
 		string[][] res = this.query(format("SELECT username FROM %s WHERE username = '%s';", users_table, escape(username)));

--- a/src/soulsetup.d
+++ b/src/soulsetup.d
@@ -208,12 +208,14 @@ void set_motd()
 
 void info()
 {
-	auto menu = new Menu("Misc. information :");
-
-	menu.info = "Soulsetup for Soulfind %s, compiled on %s\n".format(
-		VERSION, __DATE__
+	auto menu = new Menu(
+		"Soulsetup for Soulfind %s (compiled on %s)".format(VERSION, __DATE__)
 	);
-	menu.info ~= "%d registered users".format(sdb.nb_users());
+	menu.info = "\t%d registered users".format(sdb.count_users());
+	menu.info ~= "\n\t%d privileged users".format(sdb.count_users("privileges"));
+	menu.info ~= "\n\t%d banned users".format(sdb.count_users("banned"));
+
+	menu.add("1", "Recount", &info);
 	menu.add("q", "Return", &main_menu);
 
 	menu.show();
@@ -221,10 +223,10 @@ void info()
 
 void banned_users()
 {
-	auto menu = new Menu("Banned users");
+	auto menu = new Menu("Banned users (%d)".format(sdb.count_users("banned")));
 	
-	menu.add("1", "Ban an user",       &ban_user);
-	menu.add("2", "Unban an user",     &unban_user);
+	menu.add("1", "Ban user",          &ban_user);
+	menu.add("2", "Unban user",        &unban_user);
 	menu.add("3", "List banned users", &list_banned);
 	menu.add("q", "Return",            &main_menu);
 
@@ -247,16 +249,10 @@ void unban_user()
 
 void list_banned()
 {
-	auto users = sdb.get_banned_usernames();
+	auto users = sdb.get_usernames("banned");
 
-	if (!users) {
-		writeln("No user is banned.");
-		banned_users();
-		return;
-	}
-
-	writeln("\nBanned users :");
-	foreach (user ; users) writeln(format("- %s", user));
+	writeln("\nBanned users (%d)...".format(users.length));
+	foreach (user ; users) writeln(format("\t%s", user));
 
 	banned_users();
 }


### PR DESCRIPTION
In this PR, two existing functions are repurposed to get the number of users who are `privileged` or `banned` for informational display in soulsetup, but these functions could also be, for example, to count/list all users having at least a certain amount of `folders`, whose `speed` is between a given range, or any other kind of simple lookup query that is likely to be needed.

- Added: `count_users()` with filtering based on a range of minimum/maximum values of any given `filter_field`
- Added: `get_usernames()` with filtering based on a range of minimum/maximum values of any given `filter_field`
- Removed: `get_all_usernames()` unused function that was not referenced anywhere
- Fixed: A couple of minor typo's and layout tweaks in the soulsetup menus, for demonstrative purposes...

_Output of "Server info" in soulsetup:_
```
Your choice : i

Soulsetup for Soulfind 0.5.0-dev (compiled on Sep  3 2024)

	2 registered users
	2 privileged users
	1 banned users

1. Recount
q. Return

Your choice : 
```

If the `filter_field` argument is omitted, then all users are counted/retrieved regardless of their min or max values. I.e. total.

If any integer `filter_field` is specified, then by default users are counted/retrieved whose field value is non-zero.

If a string `filter_field`'s is specified, then the nature of the results are undefined, but in any case it is only integers that need to be supported.