### PR TITLE
Get MOTD template directly from config table during login

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -879,7 +879,7 @@ class User
 		if (server.is_admin(username)) writeln(username, " is an admin.");
 		server.add_user(this);
 
-		auto motd = server.get_motd(username);
+		auto motd = server.get_motd(this);
 		auto supporter = privileges > 0;
 
 		send_message(new SLogin(true, motd, address, password, supporter));

--- a/src/db.d
+++ b/src/db.d
@@ -30,7 +30,7 @@ class Sdb
 
 	this(string file, bool update = false)
 	{
-		string default_conf_format = "INSERT INTO %%s(port, max_users, motd) VALUES(%d, %d, 'Soulfind %s');".format(port, max_users, VERSION);
+		string default_conf_format = "INSERT INTO %%s(port, max_users, motd) VALUES(%d, %d, 'Soulfind %%sversion%%');".format(port, max_users);
 		if (!exists(file) || !isFile(file)) {
 			open_db(file);
 			if (!exists(file) || !isFile(file)) {

--- a/src/server.d
+++ b/src/server.d
@@ -93,7 +93,6 @@ class Server
 
 	private ushort			port;
 	private uint			max_users;
-	private string			motd;
 
 	private MonoTime		started_at;					// for server uptime
 
@@ -342,7 +341,7 @@ class Server
 				  ~ "message <message>\n\tSend global message"
 				  ~ " <message>\n\n"
 				  ~ "uptime\n\tShow server uptime\n\n"
-				  ~ "reload\n\tReload settings(Admins, MOTD, etc)"
+				  ~ "reload\n\tReload settings(Admins, etc)"
 				);
 				break;
 
@@ -587,23 +586,22 @@ class Server
 			db.user_update_field(username, "banned", 0);
 	}
 
-	string get_motd(string username)
+	string get_motd(User user)
 	{
-		auto user = get_user(username);
+		string motd;
+		auto motd_template = db.conf_get_str("motd");
 		auto client_version = "%d.%d".format(
 			user.major_version, user.minor_version);
 
-		string ret;
-		ret = replace(motd, "%version%", VERSION);
-		ret = replace(ret, "%nbusers%", nb_users.to!string);
-		ret = replace(ret, "%username%", username);
-		ret = replace(ret, "%userversion%", client_version);
-		return ret;
+		motd = replace(motd_template, "%sversion%", VERSION);
+		motd = replace(motd, "%users%", user_list.length.to!string);
+		motd = replace(motd, "%username%", user.username);
+		motd = replace(motd, "%version%", client_version);
+		return motd;
 	}
 
 	private void config(bool reload = false)
 	{
-		motd = db.conf_get_str("motd");
 		if (!reload) {
 			port = cast(ushort)db.conf_get_int("port");
 			max_users = db.conf_get_int("max_users");

--- a/src/soulsetup.d
+++ b/src/soulsetup.d
@@ -171,7 +171,7 @@ void set_max_users()
 void motd()
 {
 	auto menu = new Menu(
-		format("Current message of the day :\n--\n%s\n--\n",
+		format("Current message of the day :\n--\n%s\n--",
 			sdb.conf_get_str("motd"))
 	);
 	menu.add("1", "Change MOTD", &set_motd);
@@ -183,26 +183,26 @@ void motd()
 void set_motd()
 {
 	writeln(
-		"You can use the following variables :\n"
-		~ "%version%     : server version(", VERSION, ")\n"
-		~ "%nbusers%     : number of users already connected\n"
-		~ "%username%    : name of the connecting user\n"
-		~ "%userversion% : version of the user's client software\n"
-		~ "New MOTD(end with a dot on a single line) :"
+		"\nYou can use the following variables :"
+		~ "\n\t%sversion%    : server version (", VERSION, ")"
+		~ "\n\t%users%       : number of connected users"
+		~ "\n\t%username%    : name of the connecting user"
+		~ "\n\t%version%     : version of the user's client software"
+		~ "\n\nNew MOTD (end with a dot on a single line) :\n--"
 	);
 
-	string MOTD;
+	string motd_template;
 
 	do {
 		auto line = input.chomp;
 		if (line.strip == ".")
 			break;
-		if (MOTD.length > 0) MOTD ~= "\n";
-		MOTD ~= line;
+		if (motd_template.length > 0) motd_template ~= "\n";
+		motd_template ~= line;
 	}
 	while(true);
 
-	sdb.conf_set_field("motd", MOTD);
+	sdb.conf_set_field("motd", motd_template);
 	motd();
 }
 


### PR DESCRIPTION
Some minor refactoring...

- Removed: Don't store a copy the MOTD template in the server.d module, because it is a trivial query so just get it directly from the database instead, in order to take immediate effect of a changed MOTD template instead of having to reload
- Changed: Renamed `%version%` replacer to `%sversion%` for server version, because it ought to be used less often
- Changed: Renamed `%userversion%` replacer to `%version%` for client version, because it avoids awkward concatenation
- Changed: Renamed `%nbusers%` replacer to `%users%` for number of connected users, because the "nb" term is uncommon
- Fixed: Use the replacer string in the default motd config setting, instead of hard-coding the server version into the stored text value at the point in time when the table is created during first run, otherwise it will become outdated after updating
- Improved: Minor code and console line break formatting clean-ups related to changing MOTD template in Soulsetup
