### PR TITLE
writeln() -> writefln()

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -9,7 +9,7 @@ module db;
 import defines;
 
 import std.string : format, join, split, replace, toStringz;
-import std.stdio : writeln, write;
+import std.stdio : writefln;
 import std.file : exists, isFile, getAttributes;
 import std.conv : to, octal, ConvException;
 
@@ -160,7 +160,7 @@ class Sdb
 
 	bool get_user(string username, out uint speed, out uint upload_number, out uint something, out uint shared_files, out uint shared_folders)
 	{
-		debug(db) writeln("DB: Requested ", username, "'s info...");
+		debug(db) writefln("DB: Requested %s's info...", blue ~ username ~ norm);
 		const res = query("SELECT speed,ulnum,files,folders FROM %s WHERE username = '%s';".format(
 			users_table, escape(username)));
 		if (res.length > 0) {
@@ -178,7 +178,7 @@ class Sdb
 
 	bool get_user(string username, string password, out uint speed, out uint upload_number, out uint shared_files, out uint shared_folders, out uint privileges)
 	{
-		debug(db) writeln("DB: Requested ", username, "'s info...");
+		debug(db) writefln("DB: Requested %s's data...", blue ~ username ~ norm);
 		const res = query("SELECT speed,ulnum,files,folders,privileges FROM %s WHERE username = '%s' AND password = '%s';".format(
 			users_table, escape(username), escape(password)));
 		if (res.length > 0) {
@@ -218,7 +218,7 @@ class Sdb
 		uint res;
 		uint fin;
 
-		debug(db) writeln("DB: Query [", query, "]");
+		debug(db) writefln("DB: Query [%s]", query);
 		sqlite3_prepare_v2(db, query.toStringz(), cast(uint)query.length, &stmt, &tail);
 
 		res = sqlite3_step(stmt);
@@ -237,8 +237,8 @@ class Sdb
 
 		if (res != SQLITE_DONE || fin != SQLITE_OK) {
 			// https://sqlite.org/rescode.html#extrc
-			debug(db) writeln("DB: Result Code %d (%s)".format(res, sqlite3_errstr(res).to!string));
-			debug(db) writeln("    >Final Code %d (%s)".format(fin, sqlite3_errstr(fin).to!string));
+			debug(db) writefln("DB: Result Code %d (%s)", res, sqlite3_errstr(res).to!string);
+			debug(db) writefln("    >Final Code %d (%s)", fin, sqlite3_errstr(fin).to!string);
 			throw new Exception(sqlite3_errstr(fin).to!string);
 			return null;
 		}

--- a/src/message_codes.d
+++ b/src/message_codes.d
@@ -67,7 +67,7 @@ const GlobalRoomMessage		= 152;
 const CantConnectToPeer		= 1001;
 
 // Useful for debugging
-const message_name = [
+const string[] message_name = [
 		  1 : "Login"
 		, 2 : "SetWaitPort"
 		, 3 : "GetPeerAddress"
@@ -92,6 +92,7 @@ const message_name = [
 		, 52 : "RemoveThingILike"
 		, 54 : "GetRecommendations"
 		, 56 : "GlobalRecommendations"
+		, 57 : "UserInterests"
 		, 64 : "RoomList"
 		, 66 : "AdminMessage"
 		, 69 : "PrivilegedUsers"

--- a/src/messages.d
+++ b/src/messages.d
@@ -12,7 +12,7 @@ import std.bitmanip;
 import std.conv : to;
 import std.format : format;
 import std.outbuffer : OutBuffer;
-import std.stdio : writeln;
+import std.stdio : writefln;
 
 import message_codes;
 
@@ -70,11 +70,10 @@ class Message
 	private uint readi()
 	{ // read an int
 		uint i;
-		if (in_buf.length < uint.sizeof)
-		{
-			writeln(
-				"message code ", code, ", length ", length,
-				" not enough data trying to read an int"
+		if (in_buf.length < uint.sizeof) {
+			writefln(
+				"message code %d, length %d not enough data "
+				~ "trying to read an int", code, length
 			);
 			return i;
 		}
@@ -86,11 +85,10 @@ class Message
 	private uint readsi()
 	{ // read a signed int
 		int i;
-		if (in_buf.length < int.sizeof)
-		{
-			writeln(
-				"message code ", code, ", length ", length,
-				" not enough data trying to read a signed int"
+		if (in_buf.length < int.sizeof) {
+			writefln(
+				"message code %d, length %d not enough data "
+				~ "trying to read a signed int", code, length
 			);
 			return i;
 		}
@@ -102,11 +100,10 @@ class Message
 	private bool readb()
 	{ // read a bool
 		bool i;
-		if (in_buf.length < bool.sizeof)
-		{
-			writeln(
-				"message code ", code, ", length ", length,
-				" not enough data trying to read a bool"
+		if (in_buf.length < bool.sizeof) {
+			writefln(
+				"message code %d, length %d not enough data "
+				~ "trying to read a boolean", code, length
 			);
 			return i;
 		}

--- a/src/server.d
+++ b/src/server.d
@@ -14,7 +14,7 @@ import db;
 import room;
 import pm;
 
-import std.stdio : write, writeln;
+import std.stdio : writefln;
 import std.socket;
 import std.conv : ConvException, to;
 import std.array : split, join, replace;
@@ -32,7 +32,7 @@ import core.time : Duration, dur, MonoTime;
 
 extern(C) void handle_termination(int)
 {
-	writeln("Exiting.");
+	writefln("\nA la prochaine...");
 }
 
 @trusted
@@ -47,12 +47,12 @@ private void setup_signal_handler()
 
 private void help(string[] args)
 {
-	writeln("Usage: ", args[0], " [database_file] [-d|--daemon]");
-	writeln(
-		"\tdatabase_file: path to the sqlite3 database(default: ",
-		default_db_file, ")"
+	writefln("Usage: %s [database_file] [-d|--daemon]", args[0]);
+	writefln(
+		"\tdatabase_file: path to the sqlite3 database (default: %s)",
+		default_db_file
 	);
-	writeln("\t-d, --daemon : fork in the background");
+	writefln("\t-d, --daemon : fork in the background");
 }
 
 private int main(string[] args)
@@ -122,21 +122,18 @@ class Server
 			sock.listen(10);
 		}
 		catch (SocketOSException e) {
-			write("Unable to bind socket to port ", port);
-			if (port < 1024)
-				writeln(
-					", could it be that you're trying to use a port less than "
-					~ "1024 while running as a user ?"
-				);
-			else
-				writeln();
+			writefln("Unable to bind socket to port %d", port);
+			if (port < 1024) writefln(
+				"Are you trying to use a port less than "
+				~ "1024 while running as a user ?"
+			);
 			return 1789;
 		}
 
-		writeln(
-			bg_w, "▌", red, "♥", norm, bg_w, "▐", norm, bold,
-			"Soulfind %s process %s listening on port %s"
-			.format(VERSION ~ norm, thisProcessID, port)
+		writefln(
+			"%s process %s listening on port %s",
+			bg_w ~ "▌" ~ red ~ "♥" ~ norm ~ bg_w ~ "▐" ~ norm ~ bold
+			 ~ "Soulfind" ~ VERSION ~ norm, thisProcessID, port
 		);
 
 		auto read_socks = new SocketSet(max_users + 1);
@@ -172,12 +169,9 @@ class Server
 					);
 					new_sock.blocking = false;
 
-					debug (user) {
-						writeln(
-							"Connection accepted from ", new_sock.remoteAddress
-						);
-					}
-
+					debug (user) writefln(
+						"Connection accepted from %s", new_sock.remoteAddress
+					);
 					auto user = new User(
 						this, new_sock,
 						(cast(InternetAddress) new_sock.remoteAddress).addr
@@ -296,16 +290,11 @@ class Server
 
 	private void send_to_all(Message msg)
 	{
-		debug (msg) write(
-			"Sending message(", blue,  message_name[msg.code], norm,
-			" - code ", blue, msg.code, norm, ") to all users"
+		debug (msg) writefln(
+			"Transmit=> %s (code %d) to all users...",
+			blue ~ message_name[msg.code] ~ norm, msg.code
 		);
-		foreach (user ; users)
-		{
-			debug (msg) write(".");
-			user.send_message(msg);
-		}
-		debug (msg) writeln();
+		foreach (user ; users) user.send_message(msg);
 	}
 
 	void admin_message(User admin, string message)
@@ -381,7 +370,9 @@ class Server
 				break;
 
 			case "kickall":
-				debug (user) writeln("Admin request to kick ALL users...");
+				debug (user) writefln(
+					"Admin %s kicks ALL users...", blue ~ admin.username ~ norm
+				);
 				kick_all_users();
 				break;
 
@@ -593,11 +584,13 @@ class Server
 			return "INVALIDUSERNAME";
 
 		if (!db.user_exists(username)) {
-			debug (user) writeln("New user ", username, " registering");
+			debug (user) writefln(
+				"New user %s registering", blue ~ username ~ norm
+			);
 			db.add_user(username, encode_password(password));
 			return null;
 		}
-		debug (user) writeln("User ", username, " is registered");
+		debug (user) writefln("User %s is registered", blue ~ username ~ norm);
 
 		if (db.is_banned(username))
 			return "BANNED";

--- a/src/soulsetup.d
+++ b/src/soulsetup.d
@@ -13,7 +13,7 @@ import db;
 import std.algorithm : sort;
 import std.conv : ConvException, to;
 import std.format : format;
-import std.stdio : readf, readln, write, writeln;
+import std.stdio : readf, readln, write, writefln;
 import std.string : chomp, strip;
 
 Sdb sdb;
@@ -24,10 +24,10 @@ void main(string[] args)
 
 	if (args.length > 1) {
 		if (args[1] == "--help" || args[1] == "-h") {
-			writeln("Usage: ", args[0], " [database_file]");
-			writeln(
-				"\tdatabase_file: path to Soulfind's database "
-				~ "(default: ", default_db_file, ")"
+			writefln("Usage: %s [database_file]", args[0]);
+			writefln(
+				"\tdatabase_file: path to Soulfind's database (default: %s)",
+				default_db_file
 			);
 			return;
 		}
@@ -62,7 +62,7 @@ void main_menu()
 
 void exit()
 {
-	writeln("\nA la prochaine...");
+	writefln("\nA la prochaine...");
 }
 
 void admins()
@@ -95,8 +95,8 @@ void list_admins()
 {
 	const names = sdb.admins;
 
-	writeln(format("\nAdmins (%d)...", names.length));
-	foreach (name ; names) writeln(format("\t%s", name));
+	writefln("\nAdmins (%d)...", names.length);
+	foreach (name ; names) writefln("\t%s", name);
 
 	admins();
 }
@@ -122,7 +122,7 @@ void set_listen_port()
 	uint port;
 	try {port = value.to!uint;} catch (ConvException) {}
 	if (port <= 0 || port > ushort.max) {
-		writeln("Please enter a port in the range 1-65535");
+		writefln("Please enter a port in the range %d-%d", 1, 65535);
 		set_listen_port();
 		return;
 	}
@@ -153,7 +153,7 @@ void set_max_users()
 		num_users = value.to!uint;
 	}
 	catch (ConvException) {
-		writeln("Please enter a valid number");
+		writefln("Please enter a valid number");
 		set_max_users();
 		return;
 	}
@@ -176,9 +176,9 @@ void motd()
 
 void set_motd()
 {
-	writeln(
+	writefln(
 		"\nYou can use the following variables :"
-		~ "\n\t%sversion%    : server version (", VERSION, ")"
+		~ "\n\t%sversion%    : server version (" ~ VERSION ~ ")"
 		~ "\n\t%users%       : number of connected users"
 		~ "\n\t%username%    : name of the connecting user"
 		~ "\n\t%version%     : version of the user's client software"
@@ -245,8 +245,8 @@ void list_banned()
 {
 	const users = sdb.usernames("banned");
 
-	writeln("\nBanned users (%d)...".format(users.length));
-	foreach (user ; users) writeln(format("\t%s", user));
+	writefln("\nBanned users (%d)...", users.length);
+	foreach (user ; users) writefln("\t%s", user);
 
 	banned_users();
 }
@@ -279,18 +279,17 @@ class Menu
 
 	void show()
 	{
-		writeln(format( "\n%s\n", title));
-		if (info.length > 0) writeln(format("%s\n", info));
+		writefln("\n%s\n", title);
+		if (info.length > 0) writefln("%s\n", info);
 
 		foreach (index ; sorted_entry_indexes)
-			writeln(format("%s. %s", index, entries[index]));
+			writefln("%s. %s", index, entries[index]);
 
 		write("\nYour choice : ");
 		const choice = input.strip;
 
-		if (choice !in actions)
-		{
-			writeln(
+		if (choice !in actions) {
+			writefln(
 				"Next time, try a number which has an action "
 				~ "assigned to it..."
 			);


### PR DESCRIPTION
- Removed: `writeln()`
- Added: `writefln()` because it does implicit format string conversions
- Added: Colourized usernames in some more cases
- Changed: "Sending ->" and "Receive <-" with arrows indicating direction in place of the word "message"
- Changed: Clarified the wording of some debug messages as to who is Telling who about UserStatus
- Fixed: Broken line continuations when debug logging is enabled