### PR TITLE
Implement PBKDF2-based password hashing

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -814,9 +814,7 @@ class User
 			case ChangePassword:
 				const msg = new UChangePassword(msg_buf);
 
-				server.db.user_update_field(
-					username, "password", server.encode_password(msg.password)
-				);
+				server.db.user_update_password(username, msg.password);
 				send_message(new SChangePassword(msg.password));
 				break;
 
@@ -866,12 +864,11 @@ class User
 	private void login(const ULogin msg)
 	{
 		username = msg.username;
-		const password = server.encode_password(msg.password);
 		major_version = msg.major_version;
 		minor_version = msg.minor_version;
 
 		server.db.get_user(
-			username, password, speed, upload_number, shared_files,
+			username, null, speed, upload_number, shared_files,
 			shared_folders, privileges
 		);
 
@@ -881,7 +878,7 @@ class User
 		const motd = server.get_motd(this);
 		const supporter = privileges > 0;
 
-		send_message(new SLogin(true, motd, address, password, supporter));
+		send_message(new SLogin(true, motd, address, msg.password, supporter));
 		send_message(new SRoomList(Room.room_stats));
 		send_message(
 			new SWishlistInterval(supporter ? 120 : 720)  // in seconds

--- a/src/defines.d
+++ b/src/defines.d
@@ -11,6 +11,7 @@ const default_db_file	= "soulfind.db";
 const default_port		= 2242;
 const default_max_users	= 65535;
 const max_msg_size		= 16384;
+const pbkdf2_iterations = 100000;
 const server_user		= "server";
 
 // colours

--- a/src/messages.d
+++ b/src/messages.d
@@ -10,6 +10,8 @@ import defines;
 
 import std.bitmanip;
 import std.conv : to;
+import std.digest : LetterCase, toHexString;
+import std.digest.md : md5Of;
 import std.format : format;
 import std.outbuffer : OutBuffer;
 import std.stdio : writeln;
@@ -131,7 +133,7 @@ class ULogin : Message
 	string username;		// user name
 	string password;		// user password
 	uint   major_version;	// client version
-	string hash;			// MD5 hash of username + password
+	string digest;			// MD5 digest of username + password
 	uint   minor_version;	// client minor version
 
 	this(ubyte[] in_buf)
@@ -144,7 +146,7 @@ class ULogin : Message
 
 		if (major_version >= 155) {
 			// Older clients would not send these
-			hash = reads();
+			digest = reads();
 			minor_version = readi();
 		}
 	}
@@ -592,7 +594,7 @@ class SLogin : Message
 		if (success)
 		{
 			writei(addr);	// external IP address of the client
-			writes(password);
+			writes(md5Of(password).toHexString!(LetterCase.lower));
 			writeb(supporter);
 		}
 	}

--- a/src/server.d
+++ b/src/server.d
@@ -21,8 +21,6 @@ import std.array : split, join, replace;
 import std.ascii : isPrintable, isPunctuation;
 import std.format : format;
 import std.algorithm : canFind;
-import std.digest : digest, LetterCase, toHexString, secureEqual;
-import std.digest.md : MD5;
 import std.string : strip;
 import std.process : thisProcessID;
 import std.exception : ifThrown;
@@ -557,11 +555,6 @@ class Server
 		return dur!"seconds"(uptime.total!"seconds").toString;
 	}
 
-	string encode_password(string pass)
-	{
-		return digest!MD5(pass).toHexString!(LetterCase.lower).to!string;
-	}
-
 	bool check_name(string text, uint max_length = 24)
 	{
 		if (!text || text.length > max_length) {
@@ -599,7 +592,7 @@ class Server
 
 		if (!db.user_exists(username)) {
 			debug (user) writeln("New user ", username, " registering");
-			db.add_user(username, encode_password(password));
+			db.add_user(username, password);
 			return null;
 		}
 		debug (user) writeln("User ", username, " is registered");
@@ -607,7 +600,7 @@ class Server
 		if (db.is_banned(username))
 			return "BANNED";
 
-		if (!secureEqual(db.get_pass(username), encode_password(password)))
+		if (!db.user_password_valid(username, password))
 			return "INVALIDPASS";
 
 		return null;


### PR DESCRIPTION
Implements acceptable password hashing + salting for storing in the database. Since we don't want to use third-party libraries like bcrypt, use the remaining well-known solution PBKDF2, which is quite straightforward to implement on top of D's standard library.