### PR TITLE
client.d: is_watching() membership check optimization

### DIFF
--- a/src/client.d
+++ b/src/client.d
@@ -288,7 +288,7 @@ class User
 			return true;
 
 		foreach (room_name, room ; joined_rooms)
-			foreach (User user ; room.users) if (user.username == peer_username)
+			if (room.is_joined(peer_username))
 				return true;
 
 		return false;

--- a/src/client.d
+++ b/src/client.d
@@ -282,40 +282,30 @@ class User
 	{
 		User[] list;
 		foreach (user ; server.users)
-			if (user !is this && username in user.watching) list ~= user;
+			if (user !is this && user.is_watching(username)) list ~= user;
 
 		return list;
 	}
 
-	private User[string] watching()
+	private bool is_watching(string peer_username)
 	{
-		User[string] list;
-
-		foreach (username ; watch_list) {
-			auto user = server.get_user(username);
-			if (user) list[username] = user;
-		}
+		if (peer_username in watch_list)
+			return true;
 
 		foreach (room_name, room ; joined_rooms)
-			foreach (User user ; room.users) list[user.username] = user;
+			foreach (User user ; room.users) if (user.username == peer_username)
+				return true;
 
-		return list;
+		return false;
 	}
 
 	private void send_to_watching(Message msg)
 	{
-		if (!watched_by)
-			return;
-
-		debug (msg) write(
-			"Sending message ", blue, message_name[msg.code], norm,
-			" (code ", msg.code, ") to "
+		debug (msg) writeln(
+			"Sending message ", blue, message_name[msg.code], norm, " (code ",
+			msg.code, ") to users watching user ", blue, username, norm, "..."
 		);
-		foreach (user ; watched_by) {
-			debug (msg) writeln(user.username);
-			user.send_message(msg);
-		}
-		debug (msg) writeln();
+		foreach (user ; watched_by) user.send_message(msg);
 	}
 
 	private void set_status(uint new_status)

--- a/src/client.d
+++ b/src/client.d
@@ -278,15 +278,6 @@ class User
 			watch_list.remove(username);
 	}
 
-	private User[] watched_by()
-	{
-		User[] list;
-		foreach (user ; server.users)
-			if (user !is this && user.is_watching(username)) list ~= user;
-
-		return list;
-	}
-
 	private bool is_watching(string peer_username)
 	{
 		if (peer_username in watch_list)
@@ -305,7 +296,8 @@ class User
 			"Sending message ", blue, message_name[msg.code], norm, " (code ",
 			msg.code, ") to users watching user ", blue, username, norm, "..."
 		);
-		foreach (user ; watched_by) user.send_message(msg);
+		foreach (user ; server.users) if (user !is this)
+			if (user.is_watching(username)) user.send_message(msg);
 	}
 
 	private void set_status(uint new_status)

--- a/src/room.d
+++ b/src/room.d
@@ -125,13 +125,18 @@ class Room
 		user.join_room(this);
 	}
 
+	bool is_joined(string username)
+	{
+		return (username in user_list) ? true : false;
+	}
+
 	ulong nb_users()
 	{
 		return user_list.length;
 	}
 
 	@trusted  // .values doesn't work with @safe in old D versions
-	User[] users()
+	private User[] users()
 	{
 		return user_list.values;
 	}

--- a/src/server.d
+++ b/src/server.d
@@ -261,11 +261,6 @@ class Server
 		user_list[user.username] = user;
 	}
 
-	bool find_user(User user)
-	{
-		return (user.username in user_list) ? true : false;
-	}
-
 	User get_user(string username)
 	{
 		if (username in user_list)


### PR DESCRIPTION
- Changed: Avoid returning entire list of `users` objects just to do a `username` membership check
- Removed: Pointless iteration through `users` objects to check if iterating through `users` objects is going to happen
- Removed: `client.watched_by()` method, since it was only called (twice) by a single function
- Removed: `server.find_user()` method, since no function called it
- Added: `room.is_joined()` method for membership checking without exposing the entire `room.user_list`

Reduces unnecessary recursive iteration by several orders of magnitude.