### PR TITLE
Drop support for older versions of D and make safe

### DIFF
--- a/src/room.d
+++ b/src/room.d
@@ -32,7 +32,6 @@ class Room
 		return room_list[roomname];
 	}
 
-	@trusted  // .values doesn't work with @safe in old D versions
 	static Room[] rooms()
 	{
 		return room_list.values;
@@ -57,7 +56,6 @@ class Room
 			global_room_user_list.remove(username);
 	}
 
-	@trusted  // .keys doesn't work with @safe in old D versions
 	static string[] global_room_users()
 	{
 		return global_room_user_list.keys;
@@ -130,13 +128,11 @@ class Room
 		return user_list.length;
 	}
 
-	@trusted  // .values doesn't work with @safe in old D versions
 	User[] users()
 	{
 		return user_list.values;
 	}
 
-	@trusted  // .keys doesn't work with @safe in old D versions
 	private string[] user_names()
 	{
 		return user_list.keys;

--- a/src/server.d
+++ b/src/server.d
@@ -274,7 +274,6 @@ class Server
 		return null;
 	}
 
-	@trusted  // .keys doesn't work with @safe in old D versions
 	User[] users()
 	{
 		return user_list.values;

--- a/src/soulsetup.d
+++ b/src/soulsetup.d
@@ -269,20 +269,12 @@ class Menu
 		actions[index] = action;
 	}
 
-	@trusted  // .keys doesn't work with @safe in old D versions
-	string[] sorted_entry_indexes()
-	{
-		auto indexes = entries.keys;
-		sort(indexes);
-		return indexes;
-	}
-
 	void show()
 	{
 		writefln("\n%s\n", title);
 		if (info.length > 0) writefln("%s\n", info);
 
-		foreach (index ; sorted_entry_indexes)
+		foreach (index ; sort(entries.keys))
 			writefln("%s. %s", index, entries[index]);
 
 		write("\nYour choice : ");


### PR DESCRIPTION
Mostly reverts commit 2339eeab 

I don't need this workaround anymore, and there's no need for us to support anything other than current runtime environments (Bookworm, etc) for this project.

```
$ ldmd2 --version
LDC - the LLVM D compiler (1.30.0):
  based on DMD v2.100.1 and LLVM 14.0.6
  built with LDC - the LLVM D compiler (1.30.0)
  Default target: x86_64-pc-linux-gnu
  Host CPU: sandybridge
  http://dlang.org - http://wiki.dlang.org/LDC
```

Thanks for doing this to help get me get up and running!