### PR TITLE
soulsetup: fix num_users with active privileges in server info

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -280,23 +280,23 @@ class Sdb
         return user_stats;
     }
 
-    string[] usernames(string filter_field = null, uint min = 1, uint max = -1)
+    string[] usernames(string field = null, ulong min = 1, ulong max = -1)
     {
         string[] ret;
         auto sql = format!("SELECT username FROM %s")(users_table);
-        if (filter_field) sql ~= format!(" WHERE %s BETWEEN %d AND %d")(
-            escape(filter_field), min, max
+        if (field) sql ~= format!(" WHERE %s BETWEEN %d AND %d")(
+            escape(field), min, max
         );
         sql ~= ";";
         foreach (record ; query(sql)) ret ~= record[0];
         return ret;
     }
 
-    uint num_users(string filter_field = null, uint min = 1, uint max = -1)
+    uint num_users(string field = null, ulong min = 1, ulong max = -1)
     {
         auto sql = format!("SELECT COUNT(1) FROM %s")(users_table);
-        if (filter_field) sql ~= format!(" WHERE %s BETWEEN %d AND %d")(
-            escape(filter_field), min, max
+        if (field) sql ~= format!(" WHERE %s BETWEEN %d AND %d")(
+            escape(field), min, max
         );
         sql ~= ";";
         return query(sql)[0][0].to!uint.ifThrown(0);

--- a/src/setup/package.d
+++ b/src/setup/package.d
@@ -10,6 +10,7 @@ import soulfind.db : Sdb;
 import soulfind.defines : default_db_filename, default_max_users, default_port,
                           exit_message, VERSION;
 import std.conv : ConvException, to;
+import std.datetime : Clock;
 import std.exception : ifThrown;
 import std.format : format;
 import std.stdio : readf, readln, StdioException, write, writefln, writeln;
@@ -208,14 +209,15 @@ private void set_motd()
 private void info()
 {
     scope menu = new Menu(
-        format!("Soulsetup for Soulfind %s (compiled on %s)")(
-                VERSION, __DATE__)
+        format!("Soulfind %s (compiled on %s)")(VERSION, __DATE__)
     );
     menu.info = format!(
         "\t%d registered users
          \n\t%d privileged users
          \n\t%d banned users")(
-        sdb.num_users, sdb.num_users("privileges"), sdb.num_users("banned")
+        sdb.num_users,
+        sdb.num_users("privileges", Clock.currTime.toUnixTime),
+        sdb.num_users("banned")
     );
 
     menu.add("1", "Recount", &info);


### PR DESCRIPTION
- Fixed: Display number of currently privileged users (excluding historic supporters) in Soulsetup Server Info
- Changed: num_users(, min, max) `uint` -> `ulong` to support timestamp values that are now used in the database