### PR TITLE
db.d: implement extended error codes and throw relevant messages

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -7,9 +7,10 @@ module soulfind.db;
 @safe:
 
 import etc.c.sqlite3 : sqlite3, sqlite3_close, sqlite3_column_count,
-                       sqlite3_column_text, sqlite3_errstr, sqlite3_finalize,
+                       sqlite3_column_text, sqlite3_errmsg, sqlite3_errstr,
+                       sqlite3_extended_errcode, sqlite3_finalize,
                        sqlite3_open, sqlite3_prepare_v2, sqlite3_step,
-                       sqlite3_stmt, SQLITE_DONE, SQLITE_OK, SQLITE_ROW;
+                       sqlite3_stmt, SQLITE_ROW;
 import soulfind.defines : blue, default_max_users, default_port, norm;
 import std.conv : to;
 import std.exception : ifThrown;
@@ -307,14 +308,11 @@ class Sdb
     {
         string[][] ret;
         char* tail;
-        uint res;
-        uint fin;
 
-        debug(db) writefln!("DB: Query [%s]")(query);
         sqlite3_prepare_v2(
             db, query.toStringz(), cast(uint)query.length, &stmt, &tail);
 
-        res = sqlite3_step(stmt);
+        uint res = sqlite3_step(stmt);
 
         while (res == SQLITE_ROW) {
             string[] record;
@@ -327,17 +325,17 @@ class Sdb
             res = sqlite3_step(stmt);
         }
 
-        fin = sqlite3_finalize(stmt);
+        uint fin = sqlite3_finalize(stmt);
+        uint err = sqlite3_extended_errcode(db);
 
-        if (res != SQLITE_DONE || fin != SQLITE_OK) {
-            // https://sqlite.org/rescode.html#extrc
-            debug(db) writefln!("DB: Result Code %d (%s)")(
-                res, sqlite3_errstr(res).to!string
+        if (err) {
+            writefln!(
+                "DB: Query [%s]\nDB: Result Code %d, Final Code %d.\n\n%s\n")(
+                query, res, fin, sqlite3_errmsg(db).to!string
             );
-            debug(db) writefln!("    >Final Code %d (%s)")(
-                fin, sqlite3_errstr(fin).to!string
+            throw new Exception(
+                format!("Error %d (%s)")(err, sqlite3_errstr(err).to!string)
             );
-            throw new Exception(sqlite3_errstr(fin).to!string);
         }
         return ret;
     }


### PR DESCRIPTION
- Fixed: Throw an actual error code instead of the final result code (which is usually `0`)
- Removed: Hide the query string in debug(db) builds unless throwing an error, because it's not often helpful and is too noisy
- Changed: Always show complete text of error messages in all builds including release builds, rather than only codes.

Since the faulty implementation in #11, any thrown error was always [code 21 (SQLITE_MISUSE)](https://www.sqlite.org/rescode.html#misuse) "bad parameter or other API misuse" because the argument to `sqlite_errstr()` has to be an [error code rather than a result code](https://www.sqlite.org/rescode.html#result_codes_versus_error_codes). 

This PR corrects that mistake and produces a more helpful [extended error message](https://www.sqlite.org/c3ref/c_abort_rollback.html) or [normal error message](https://www.sqlite.org/c3ref/c_abort.html).


<details><summary>For example...</summary>
<p>

... setting `sqlite3_limit(db, SQLITE_LIMIT_COLUMN, 7);` (whereas a table with `8` columns exists) throws [code 11 (SQLITE_CORRUPT)](https://www.sqlite.org/rescode.html#corrupt) which outputs...

```
DB: Query [CREATE TABLE IF NOT EXISTS users( username TEXT PRIMARY KEY, password TEXT, speed INTEGER, ulnum INTEGER, files INTEGER, folders INTEGER, banned INTEGER, privileges INTEGER) WITHOUT ROWID;]
DB: Result Code 21, Final Code 0.

malformed database schema (users) - too many columns on users

object.Exception@src/db.d(410): Error 11 (database disk image is malformed)
----------------
src/db.d:410 [0x55d26357a23c]
...
DB: Shutting down...
$ 
```

... including both codes and texts of all possible data that are available, and providing a useful message in this example case.

When there isn't an error, the `debug=db` build of the program is actually usable because each and every query isn't shown...

```
$ soulfind
DB: Using database: soulfind.db
♥ Soulfind 0.5.0-dev process 3457731 listening on port 2242
```

... If always showing all the raw queries on the console is desired then i'd suggest another `sql` debug category, but it's just as easy to temporarily add a `debug(db) writefln!("DB: Query [%s]")(query);` line into the code where needed.

</p>
</details> 