### PR TITLE
db.d: run integrity check and optimize all tables at startup

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -68,6 +68,10 @@ class Sdb
             admins_table
         );
 
+        foreach (problem ; query("PRAGMA integrity_check;"))
+            debug(db) writefln!("DB: Check [%s]")(problem[0]);
+
+        query("PRAGMA optimize=0x10002;");  // =all tables
         query(users_sql);
         query(admins_sql);
         init_config();
@@ -194,6 +198,7 @@ class Sdb
             users_table, escape(username), escape(password)
         );
         query(sql);
+        query("PRAGMA optimize;");
     }
 
     bool user_exists(string username)


### PR DESCRIPTION
It seems like a good idea to run some non-destructive query at startup so an error might be thrown if something serious is wrong with the database before attempting any writes. These commands are usually a no-op and so are very fast...

- Added: Run [integrity_check](https://www.sqlite.org/pragma.html#pragma_integrity_check) on all tables at startup to validate schema and output any warnings to debug(db)
- Added: Run [optimize](https://www.sqlite.org/pragma.html#pragma_optimize) on all tables at startup to analyze and build or update the autoindexes 
- Added: Run [optimize periodically](https://www.sqlite.org/lang_analyze.html#periodically_run_pragma_optimize_), i.e. when adding users. SQLite usually skips this unless the number of records have increased by 10-fold since last optimized.

Note the optimize() pragma is only fully effective in SQLite 3.46.0 (2024-05-23) or above. Very old versions are a no-op.