### PR TITLE
GivePrivileges: fix time comparison between days and seconds

### DIFF
--- a/src/server/messages.d
+++ b/src/server/messages.d
@@ -570,14 +570,14 @@ class UUserPrivileged : UMessage
 class UGivePrivileges : UMessage
 {
     string  username;
-    uint    time;
+    uint    days;
 
     this(ubyte[] in_buf, string in_username) scope
     {
         super(in_buf, in_username);
 
         username = read!string();
-        time     = read!uint();
+        days     = read!uint();
     }
 }
 

--- a/src/server/user.d
+++ b/src/server/user.d
@@ -6,7 +6,7 @@
 module soulfind.server.user;
 @safe:
 
-import core.time : seconds;
+import core.time : days, seconds;
 import soulfind.defines : blue, max_msg_size, norm, red, server_username;
 import soulfind.server.messages;
 import soulfind.server.pm : PM;
@@ -154,7 +154,7 @@ class User
         );
     }
 
-    long privileges()
+    private long privileges()
     {
         long privileges = priv_expiration - Clock.currTime.toUnixTime;
         if (privileges <= 0) privileges = 0;
@@ -901,11 +901,11 @@ class User
                 const admin = server.db.is_admin(msg.username);
                 if (!user)
                     break;
-                if (msg.time > privileges && !admin)
+                if (days(msg.days) > seconds(privileges) && !admin)
                     break;
 
-                user.add_privileges(msg.time * 3600 * 24);
-                if (!admin) remove_privileges(msg.time * 3600 * 24);
+                user.add_privileges(msg.days * 3600 * 24);
+                if (!admin) remove_privileges(msg.days * 3600 * 24);
                 break;
 
             case ChangePassword:


### PR DESCRIPTION
- Fixed: A user could give way more privileges than he had, because the client provides the number of days to give, whereas the server calculates the remaining privileges in seconds, so this `>` comparison was off by a factor of 86400.
- Renamed `msg.time` -> `msg.days` to clarify that this integer value is [specified in days](https://github.com/nicotine-plus/nicotine-plus/blob/master/doc/SLSKPROTOCOL.md#server-code-123) and not seconds.

This bug was found while working on https://github.com/slook/soulfind/commit/20522ac247cef79e25e0ec24636df1aa14c4834f that parses time values using the `Duration` data type to add or remove privileges, with the intent of reducing the risk of this type of confusion.