### PR TITLE
Use compilation date as version number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 
 # News
 
+Historical release notes predating the switch to rolling builds. See the
+[commit log](https://github.com/soulfind-dev/soulfind/commits/HEAD/) for recent
+changes.
+
+
 ## 0.5.0-dev (Unstable)
 
  - Relicenced to GNU General Public License v3.0 or later

--- a/src/defines.d
+++ b/src/defines.d
@@ -7,10 +7,11 @@ module soulfind.defines;
 @safe:
 
 import core.time : minutes, seconds;
+import std.string : replace;
 
 // Constants
 
-const VERSION                  = "0.5.0-dev";
+const VERSION                  = __DATE__.replace("  ", " ").replace(" ", "-");
 const default_db_filename      = "soulfind.db";
 const default_port             = 2242;
 const default_max_users        = 65535;

--- a/src/server/package.d
+++ b/src/server/package.d
@@ -66,9 +66,9 @@ int run(string[] args)
 
     if (show_version) {
         writefln(
-            "Soulfind %s (%s)"
-          ~ "\nCompiled with %s %s.%s on %s",
-            VERSION, os, name, version_major, version_minor, __DATE__
+            "Soulfind %s"
+          ~ "\nCompiled with %s %s.%s for %s",
+            VERSION, name, version_major, version_minor, os
         );
         return 0;
     }

--- a/src/setup/package.d
+++ b/src/setup/package.d
@@ -58,9 +58,9 @@ int run(string[] args)
 
     if (show_version) {
         writefln(
-            "Soulfind %s (%s)"
-          ~ "\nCompiled with %s %s.%s on %s",
-            VERSION, os, name, version_major, version_minor, __DATE__
+            "Soulfind %s"
+          ~ "\nCompiled with %s %s.%s for %s",
+            VERSION, name, version_major, version_minor, os
         );
         return 0;
     }

--- a/src/setup/setup.d
+++ b/src/setup/setup.d
@@ -293,13 +293,12 @@ class Setup
         show_menu(
             format!(
                 "Soulfind %s"
-              ~ "\n\tOS: %s"
-              ~ "\n\tCompiled with %s %s.%s on %s"
+              ~ "\n\tCompiled with %s %s.%s for %s"
               ~ "\n\nStats:"
               ~ "\n\t%d registered users"
               ~ "\n\t%d privileged users"
               ~ "\n\t%d banned users")(
-                VERSION, os, name, version_major, version_minor, __DATE__,
+                VERSION, name, version_major, version_minor, os,
                 db.num_users,
                 db.num_users("privileges", Clock.currTime.toUnixTime),
                 db.num_users("banned", Clock.currTime.toUnixTime)


### PR DESCRIPTION
I have no plans to do stable releases in the future, since Soulfind isn't supposed to be included in stable distributions. A single rolling build simplifies maintenance, and gives us a single build to point users to. The commit log replaces the release notes.