### PR TITLE
soulsetup: require existence of registered user to make admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ utility.
 Admins can interact with the server by sending commands in a private
 chat with the `server` user (`help` to see all commands).
 
-> [!IMPORTANT]
-> If an owner adds a username to the admin list before the user has registered
-a password, it is no longer possible to register through the Soulseek client.
-Only an owner can register the user in the `Registered users` section in the
-`soulsetup` utility.
-
 
 ## Runtime Options
 

--- a/src/server/user.d
+++ b/src/server/user.d
@@ -123,6 +123,11 @@ class User
     {
         auto login_rejection = LoginRejection();
 
+        if (password.length == 0) {
+            login_rejection.reason = LoginRejectionReason.empty_password;
+            return login_rejection;
+        }
+
         if (server.users.length >= server.db.server_max_users) {
             login_rejection.reason = LoginRejectionReason.server_full;
             return login_rejection;
@@ -138,15 +143,6 @@ class User
         if (!server.db.user_exists(username)) {
             if (server.db.server_private_mode)
                 login_rejection.reason = LoginRejectionReason.server_private;
-
-            else if (password.length == 0)
-                login_rejection.reason = LoginRejectionReason.empty_password;
-
-            else if (server.db.is_admin(username))
-                // For security reasons, non-existent admins cannot register
-                // through the client
-                login_rejection.reason = LoginRejectionReason.invalid_password;
-
             else
                 server.db.add_user(username, password);
 

--- a/src/setup/setup.d
+++ b/src/setup/setup.d
@@ -112,26 +112,13 @@ class Setup
     private void add_admin()
     {
         write("Admin to add : ");
-
         const username = input.strip;
-        if (!db.user_exists(username)) {
-            do {
-                writefln(
-                    "User %s is not registered. Do you really want to add "
-                  ~ "them to the admin list? [y/n]", username
-                );
-                const response = input.strip.toLower;
-                if (response == "y") {
-                    db.add_admin(username);
-                    break;
-                } else if (response == "n") {
-                    break;
-                }
-            }
-            while(true);
-        } else {
+
+        if (db.user_exists(username))
             db.add_admin(username);
-        }
+        else
+            writefln!("\nUser %s is not registered")(username);
+
         admins();
     }
 


### PR DESCRIPTION
+ Changed: require existence of registered user to make admin
+ Changed: Always reject an empty password before checking if a user exists or if the server is full or in private mode _(idk if this differs from the behaviour of the official server as I have no easy way to test that, if it does then I can revert this)_.

- Removed: Possible timing attack vulnerability of calling the admins table from verify_login() where it could be possible for an alien to detect the presence of a name in the admins table because no checking of the password hash would have occurred.
- Removed: Important caveat from README.md because it makes more sense for this scenario to be annulled by forcing user registration to occur before adding the admin, which is possible to do either from a client or, if required, from the setup menu.