### PR TITLE
server.d: correct output for users banned command syntax

### DIFF
--- a/src/server/server.d
+++ b/src/server/server.d
@@ -540,7 +540,7 @@ class Server
                 const users = db.usernames(
                     "banned", Clock.currTime.toUnixTime
                 );
-                output ~= format!("\nBanned users (%d)...")(users.length);
+                output ~= format!("%d banned users.")(users.length);
                 foreach (ref user ; users) {
                     const banned_until = db.user_banned_until(user);
                     if (banned_until == SysTime.fromUnixTime(long.max))
@@ -551,11 +551,16 @@ class Server
                 }
                 break;
 
-            default:
+            case null:
                 const usernames = db.usernames;
                 output ~= format!("%d total users.")(usernames.length);
                 foreach (ref username ; db.usernames)
                     output ~= format!("\n\t%s")(username);
+                break;
+
+            default:
+                output ~= "Syntax is : users [connected|banned|privileged]";
+
         }
         return output[];
     }


### PR DESCRIPTION
+ Fixed: Use correct output for `users banned` command without leading newline typo, the same as used for other outputs.
+ Added: Validate choice if the optional argument is specified for the `users` command, because its too easy to make a spelling mistake which leads to getting the wrong information.