### PR TITLE
Implement PBKDF2 password hashing

### DIFF
--- a/src/defines.d
+++ b/src/defines.d
@@ -34,6 +34,7 @@ const max_global_recommendations  = 200;
 const max_user_recommendations    = 100;
 const max_room_tickers            = 200;
 const speed_weight                = 50;
+const pbkdf2_iterations           = 100000;
 const server_username             = "server";
 const exit_message                = "A la prochaine...";
 

--- a/src/pwhash.d
+++ b/src/pwhash.d
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2024-2025 Soulfind Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+module soulfind.pwhash;
+@safe:
+
+import std.algorithm.iteration : splitter;
+import std.bitmanip : nativeToBigEndian;
+import std.conv : ConvException, text, to;
+import std.digest : LetterCase, secureEqual, toHexString;
+import std.digest.hmac : HMAC;
+import std.digest.sha : SHA512;
+import std.parallelism : Task, task, taskPool;
+import std.random : unpredictableSeed;
+import std.string : split;
+
+private alias HashTask    = Task!(hash_password_task, string, string, uint)*;
+private alias VerifyTask  = Task!(verify_password_task, string, string)*;
+
+private alias HashCallback    = void delegate(string, string);
+private alias VerifyCallback  = void delegate(string, bool, uint);
+
+private HashTask[HashCallback]      hash_password_tasks;
+private VerifyTask[VerifyCallback]  verify_password_tasks;
+
+struct VerifyPasswordResult
+{
+    bool  matches;
+    uint  iterations;
+}
+
+string create_salt()
+{
+    const length = 16;
+    ubyte[length] salt;
+    ubyte offset;
+
+    foreach (_; 0 .. length / uint.sizeof) {
+        // unpredictableSeed is cryptographically secure on all operating
+        // systems we care about (Linux, macOS, Windows, BSDs) in recent
+        // D versions
+        salt[offset .. offset + uint.sizeof] = unpredictableSeed
+            .nativeToBigEndian;
+        offset += uint.sizeof;
+    }
+
+    return salt.toHexString!(LetterCase.lower).idup;
+}
+
+string hash_password(string password, string salt, uint iterations)
+{
+    const algorithm = "pbkdf2-sha512";
+    auto hmac = HMAC!SHA512(cast(immutable(ubyte)[]) password);
+    auto digest = hmac
+        .put(cast(immutable(ubyte)[]) salt)
+        .put(1.nativeToBigEndian)
+        .finish();
+    auto iter_digest = digest;
+
+    foreach (i; 1 .. iterations) {
+        iter_digest = hmac.put(iter_digest).finish();
+        foreach (n, ref c; digest) c ^= iter_digest[n];
+    }
+
+    // PHC string format
+    return text(
+        "$", algorithm, "$i=", iterations, "$", salt, "$",
+        digest.toHexString!(LetterCase.lower)
+    );
+}
+
+void hash_password_async(string password, string salt, uint iterations,
+                         HashCallback callback)
+{
+    auto task = task!hash_password_task(password, salt, iterations);
+    taskPool.put(task);
+    hash_password_tasks[callback] = task;
+}
+
+VerifyPasswordResult verify_password(string hash, string password)
+{
+    auto result = VerifyPasswordResult();
+    auto hash_parts = hash.splitter("$");
+
+    if (hash_parts.empty || hash_parts.front.length != 0)
+        return result;
+
+    hash_parts.popFront();
+
+    if (hash_parts.empty || hash_parts.front != "pbkdf2-sha512")
+        return result;
+
+    hash_parts.popFront();
+
+    if (hash_parts.empty)
+        return result;
+
+    foreach (param; hash_parts.front.splitter(",")) {
+        const parts = param.split("=");
+        if (parts.length != 2)
+            continue;
+
+        if (parts[0] == "i")
+            try result.iterations = parts[1].to!uint; catch (ConvException) {}
+    }
+    if (result.iterations == 0)
+        return result;
+
+    hash_parts.popFront();
+
+    if (hash_parts.empty)
+        return result;
+
+    const salt = hash_parts.front;
+    const current_hash = hash_password(password, salt, result.iterations);
+    result.matches = secureEqual(current_hash, hash);
+    return result;
+}
+
+void verify_password_async(string hash, string password,
+                           VerifyCallback callback)
+{
+    auto task = task!verify_password_task(hash, password);
+    taskPool.put(task);
+    verify_password_tasks[callback] = task;
+}
+
+void process_password_tasks()
+{
+    HashCallback[]    hash_password_tasks_to_remove;
+    VerifyCallback[]  verify_password_tasks_to_remove;
+
+    foreach (ref callback, ref task ; hash_password_tasks) {
+        if (!task.done)
+            continue;
+
+        auto result = task.yieldForce;
+        callback(result.password, result.hash);
+        hash_password_tasks_to_remove ~= callback;
+    }
+    foreach (ref callback ; hash_password_tasks_to_remove)
+        hash_password_tasks.remove(callback);
+
+    foreach (ref callback, ref task ; verify_password_tasks) {
+        if (!task.done)
+            continue;
+
+        auto result = task.yieldForce;
+        callback(result.password, result.matches, result.iterations);
+        verify_password_tasks_to_remove ~= callback;
+    }
+    foreach (ref callback ; verify_password_tasks_to_remove)
+        verify_password_tasks.remove(callback);
+}
+
+
+// Threaded Tasks
+
+private struct TaskResult
+{
+    string  hash;
+    string  password;
+    bool    matches;
+    uint    iterations;
+}
+
+TaskResult hash_password_task(string password, string salt, uint iterations)
+{
+    const hash = hash_password(password, salt, iterations);
+    return TaskResult(hash, password);
+}
+
+TaskResult verify_password_task(string hash, string password)
+{
+    const result = verify_password(hash, password);
+    return TaskResult(hash, password, result.matches, result.iterations);
+}

--- a/src/setup/setup.d
+++ b/src/setup/setup.d
@@ -8,13 +8,12 @@ module soulfind.setup.setup;
 
 import core.time : days, Duration;
 import soulfind.db : Sdb;
-import soulfind.defines : VERSION;
+import soulfind.defines : pbkdf2_iterations, VERSION;
+import soulfind.pwhash : create_salt, hash_password;
 import std.array : Appender;
 import std.compiler : name, version_major, version_minor;
 import std.conv : ConvException, text, to;
 import std.datetime.systime : Clock, SysTime;
-import std.digest : digest, LetterCase, toHexString;
-import std.digest.md : MD5;
 import std.stdio : readln, StdioException, write, writeln;
 import std.string : chomp, strip, toLower;
 
@@ -364,7 +363,9 @@ final class Setup
         }
         while(true);
 
-        db.add_user(username, password);
+        const salt = create_salt();
+        const hash = hash_password(password, salt, pbkdf2_iterations);
+        db.add_user(username, hash);
         registered_users();
     }
 
@@ -429,7 +430,9 @@ final class Setup
             }
             while(true);
 
-            db.user_update_password(username, password);
+            const salt = create_salt();
+            const hash = hash_password(password, salt, pbkdf2_iterations);
+            db.user_update_password(username, hash);
         }
         else
             writeln("\nUser ", username, " is not registered");

--- a/src/tests/pwhash.d
+++ b/src/tests/pwhash.d
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2024-2025 Soulfind Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+module soulfind.tests.pwhash2;
+@safe:
+
+import soulfind.pwhash;
+import std.algorithm.searching : all;
+import std.ascii : isDigit, isHexDigit, isLower;
+import std.conv : text;
+import std.digest : secureEqual;
+
+/// Short password, fewer iterations
+@safe unittest
+{
+    const password = "abc123";
+    const invalid_password = password ~ "junk";
+    const salt = "d7679b9a8b6ebe430f6b6fec2b9e0d67";
+    const iterations = 100000;
+    const hash = hash_password(password, salt, iterations);
+    const invalid_hash = hash_password(invalid_password, salt, iterations);
+    const expected_hash = text(
+        "$", "pbkdf2-sha512", "$i=", iterations, "$", salt, "$",
+        "a64992f627696932f21f4082c97f520e235ae44fd5d36440df65d6a345aca3bfad3f"
+      ~ "ed5c256a1e9fa463aa0462f86b591d532dc5664ef16764258196f1b6ab0e"
+    );
+    const verify_result = verify_password(hash, password);
+    const invalid_verify_result = verify_password(hash, invalid_password);
+
+    assert(secureEqual(hash, expected_hash), "Hashes must match");
+    assert(!secureEqual(invalid_hash, expected_hash), "Hashes must not match");
+
+    assert(verify_result.matches, "Password must be valid");
+    assert(!invalid_verify_result.matches, "Password must be invalid");
+
+    assert(verify_result.iterations == iterations, "Iterations must match");
+    assert(
+        invalid_verify_result.iterations == iterations, "Iterations must match"
+    );
+}
+
+/// Long password, more iterations
+@safe unittest
+{
+    const password = "long_password_123_@/&%¤(#¤#&/¤&_093402347234298372";
+    const invalid_password = password ~ "junk";
+    const salt = "61e9f5e5607f5cdd95afbf4ae2bcd36d";
+    const iterations = 1000000;
+    const hash = hash_password(password, salt, iterations);
+    const invalid_hash = hash_password(invalid_password, salt, iterations);
+    const expected_hash = text(
+        "$", "pbkdf2-sha512", "$i=", iterations, "$", salt, "$",
+        "8e222d416e603f6516101943165445c6f8ba041e464961fb0260069f8baaa9da9876"
+      ~ "d04c7af6f9307b2377d3dc3cec8155b06aaf0a0d500919ecc9a0b26e956b"
+    );
+    const verify_result = verify_password(hash, password);
+    const invalid_verify_result = verify_password(hash, invalid_password);
+
+    assert(secureEqual(hash, expected_hash), "Hashes must match");
+    assert(!secureEqual(invalid_hash, expected_hash), "Hashes must not match");
+
+    assert(verify_result.matches, "Password must be valid");
+    assert(!invalid_verify_result.matches, "Password must be invalid");
+
+    assert(verify_result.iterations == iterations, "Iterations must match");
+    assert(
+        invalid_verify_result.iterations == iterations, "Iterations must match"
+    );
+}
+
+/// Salt validity
+@safe unittest
+{
+    const salt = create_salt();
+
+    assert(salt.length == 32, "Invalid salt length");
+    assert(
+        salt.all!(c => c.isHexDigit && (c.isDigit || c.isLower)),
+        "Invalid salt"
+    );
+}
+
+/// Salt uniqueness
+@safe unittest
+{
+    const num_salts = 100000;
+    uint[string] salts;
+
+    foreach (i; 0 .. num_salts) {
+        const salt = create_salt();
+        salts[salt] = i;
+    }
+
+    assert(salts.length == num_salts, "Duplicate salts found");
+}


### PR DESCRIPTION
Implements PBKDF2 password hashing with the help of D's std.digest module. Salts are generated using std.random's unpredictableSeed() function, which is cryptographically secure on most operating systems in recent D versions.

Hashed passwords are stored in the PHC string format:

`$<id>$<iterations>=<value>$<salt>$<hash>`

Includes unit tests.

While the database schema stays unchanged, previously registered users will not be able to log in, unless the soulsetup tool is used to remove them or change their passwords.