### PR TITLE
Add expiration date for admin statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,6 @@ utility.
 Admins can interact with the server by sending commands in a private
 chat with the `server` user (`help` to see all commands).
 
-> [!IMPORTANT]
-> If an owner adds a username to the admin list before the user has registered
-a password, it is no longer possible to register through the Soulseek client.
-Only an owner can register the user in the `Registered users` section in the
-`soulsetup` utility.
-
 
 ## Runtime Options
 

--- a/src/server/user.d
+++ b/src/server/user.d
@@ -149,13 +149,7 @@ final class User
         }
 
         if (!user_exists) {
-            if (server.db.is_admin(username))
-                // For security reasons, non-existent admins cannot register
-                // through the client
-                login_rejection.reason = LoginRejectionReason.invalid_password;
-            else
-                server.db.add_user(username, password);
-
+            server.db.add_user(username, password);
             return login_rejection;
         }
 


### PR DESCRIPTION
Removes the admin table, and adds an expiration date for the admin status to the users table. This effectively ties the admin status to registered users only.