### PR TITLE
soulsetup: add CLI argument to safely back up database

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ from source.
 
 Soulfind stores all its configuration in a SQLite database, and looks for the
 file `soulfind.db` by default, unless provided a different path as a
-`--database` argument.
+`--database` argument. See [Database File](#database-file) under runtime
+options.
 
 Server owners can configure the server and add admins using the `soulsetup`
-CLI server management tool.
+CLI server management tool. The main database can be backed up safely by
+providing a target file path as a `--backup` argument when running `soulsetup`.
+See [Backup File](#backup-file) under runtime options.
 
 Admins can interact with the server from a Soulseek client, by sending commands
 to the `server` user in a private chat (`help` to see all commands).
@@ -80,6 +83,16 @@ soulfind -d path/to/database.db
 
 ```
 soulsetup -d path/to/database.db
+```
+
+### Backup File
+
+Back up the main database file to a target path by providing `soulsetup` a `-b`
+or `--backup` argument. This is useful for automatic backups using e.g. a cron
+job, and is safe even while the database is in use.
+
+```
+soulsetup -b path/to/save/backup.db
 ```
 
 ### Listening Port

--- a/src/setup/package.d
+++ b/src/setup/package.d
@@ -15,6 +15,7 @@ import std.stdio : writeln;
 int run(string[] args)
 {
     string  db_filename = default_db_filename;
+    string  db_backup_filename;
     bool    show_version;
     bool    show_help;
 
@@ -24,6 +25,12 @@ int run(string[] args)
                 "Database path (default: ", default_db_filename, ")."
             ), "path",
             (value) { db_filename = value; }
+        ),
+        CommandOption(
+            "b", "backup", text(
+                "Back up database to file path."
+            ), "path",
+            (value) { db_backup_filename = value; }
         ),
         CommandOption(
             "v", "version", "Show version.", null,
@@ -52,8 +59,16 @@ int run(string[] args)
         return 0;
     }
 
+    int exit_code;
     auto setup = new Setup(db_filename);
-    const exit_code = setup.show();
+
+    if (db_backup_filename !is null) {
+        const success = setup.backup_db(db_backup_filename);
+        exit_code = success ? 0 : 1;
+        return exit_code;
+    }
+
+    setup.show();
 
     writeln("\n", exit_message);
     return exit_code;

--- a/src/setup/setup.d
+++ b/src/setup/setup.d
@@ -34,10 +34,14 @@ final class Setup
         this.db  = new Sdb(db_filename);
     }
 
-    int show()
+    void show()
     {
         try main_menu(); catch (StdioException) {}
-        return 0;
+    }
+
+    bool backup_db(string filename)
+    {
+        return db.backup(filename);
     }
 
     @trusted


### PR DESCRIPTION
This makes it easy to safely back up the database while it's in use, without the need for external tools.