### PR TITLE
Replace client 'version' with 'variant', 'type' and 'subtype'

### DIFF
--- a/src/server/cmdhandler.d
+++ b/src/server/cmdhandler.d
@@ -461,7 +461,7 @@ final class CommandHandler
                 output ~= "\n    ";
                 output ~= user.username;
                 output ~= text(
-                    " (client version: ", user.client_version, ")"
+                    " (client variant: ", user.client_variant, ")"
                 );
             }
             break;
@@ -520,7 +520,7 @@ final class CommandHandler
         User user;
         const now = Clock.currTime;
         auto status = "offline";
-        auto client_version = "none";
+        auto client_variant = "none";
         auto ip_address = "none";
         ushort listening_port;
         ushort obfuscated_port;
@@ -543,7 +543,7 @@ final class CommandHandler
         user = server.get_user(username);
         if (user !is null) {
             status = (user.status == UserStatus.away) ? "away" : "online";
-            client_version = user.client_version;
+            client_variant = user.client_variant;
             ip_address = user.address.toAddrString;
             listening_port = user.address.port;
             obfuscated_port = user.obfuscated_port;
@@ -601,7 +601,7 @@ final class CommandHandler
             "\n",
             "\nSession info:",
             "\n    status: ", status,
-            "\n    client version: ", client_version,
+            "\n    client variant: ", client_variant,
             "\n    IP address: ", ip_address,
             "\n    port: ", listening_port,
             "\n    obfuscated port: ", obfuscated_port,
@@ -786,7 +786,7 @@ final class CommandHandler
             "\n    \"username\": \"", username, "\",",
             "\n    \"session_data\": {",
             "\n        \"status\": \"", status, "\",",
-            "\n        \"client_version\": \"", user.client_version, "\",",
+            "\n        \"client_variant\": \"", user.client_variant, "\",",
             "\n        \"ip_address\": \"", user.address.toAddrString ~ "\",",
             "\n        \"port\": ", user.address.port, ",",
             "\n        \"obfuscated_port\": ", user.obfuscated_port, ",",

--- a/src/server/messages.d
+++ b/src/server/messages.d
@@ -259,24 +259,24 @@ final class ULogin : UMessage
 {
     string  username;
     string  password;
-    uint    major_version;
+    uint    client_type;     // protocol major version
     string  hash;            // MD5 hash of username + password
-    uint    minor_version;
+    uint    client_subtype;  // protocol minor version
 
     this(const(ubyte)[] in_buf) scope
     {
         super(in_buf);
 
-        username      = read!string();
-        password      = read!string();
-        major_version = read!uint();
+        username    = read!string();
+        password    = read!string();
+        client_type = read!uint();
 
         if (!has_unread_data)
             return;
 
         // Older clients would not send these
-        hash          = read!string();
-        minor_version = read!uint();
+        hash           = read!string();
+        client_subtype = read!uint();
     }
 }
 

--- a/src/server/msghandler.d
+++ b/src/server/msghandler.d
@@ -44,8 +44,8 @@ final class MessageHandler
                 break;
 
             user.username = msg.username;
-            user.client_version = text(
-                msg.major_version, ".", msg.minor_version
+            user.client_variant = text(
+                msg.client_type, ".", msg.client_subtype
             );
             user.authenticate(msg.username, msg.password);
             break;

--- a/src/server/user.d
+++ b/src/server/user.d
@@ -34,7 +34,7 @@ import std.string : replace, strip, toLower;
 final class User
 {
     string                  username;
-    string                  client_version;
+    string                  client_variant;
     InternetAddress         address;
     ObfuscationType         obfuscation_type;
     ushort                  obfuscated_port;
@@ -79,7 +79,7 @@ final class User
             .replace("%sversion%", VERSION)
             .replace("%users%", server.num_connected_users.text)
             .replace("%username%", username)
-            .replace("%version%", client_version);
+            .replace("%variant%", client_variant);
     }
 
     bool login_timed_out(MonoTime current_time)
@@ -352,7 +352,7 @@ final class User
         writeln(
             server.db.admin_until(username) > Clock.currTime ?
             "Admin " : "User ", blue, username, norm,
-            " logged in with client version ", bold, client_version, norm
+            " logged in using client variant ", bold, client_variant, norm
         );
 
         server.add_user(this);

--- a/src/setup/setup.d
+++ b/src/setup/setup.d
@@ -300,7 +300,7 @@ final class Setup
             "\n\t%%sversion%% - server version (", VERSION, ")",
             "\n\t%%users%%    - number of connected users",
             "\n\t%%username%% - name of the connecting user",
-            "\n\t%%version%%  - version of the user's client software",
+            "\n\t%%variant%%  - user's client type and subtype",
             "\n\nNew MOTD (end with a dot on a single line):"
         );
 


### PR DESCRIPTION
There is ambiguity about the purpose of the "major version" and "minor version" values as to what they are supposed to represent. It needs to be made clearer that project maintainers must avoid impersonating other client implementations.

- Changed: `client_version` -> `client_variant` because this isn't the "version of the user's client software"
- Changed: `major_version` -> `client_type` because this is expected to be constant as to a particular project
- Changed: `minor_version` -> `client_subtype` because this is unrelated to the user's client software version
- Changed: "%version%" -> "%variant%" because it is ambiguous with "%sversion%" could become "%version%"

Other possible alternatives considered for "major" -> "type" | "identifier" | "kind" | "family" | "class" ...?
Other possible alternatives considered for "minor" -> "subtype" | "revision" | "generation" | "subclass" ...?