### PR TITLE
Add --rx-bytes flag to enable logging of received bytes in hexadecimal

### DIFF
--- a/src/defines.d
+++ b/src/defines.d
@@ -101,3 +101,4 @@ enum red                         = "\033[01;91m";    // foreground red
 bool log_db;
 bool log_conn;
 bool log_msg;
+bool log_bytes_rx;

--- a/src/server/messages.d
+++ b/src/server/messages.d
@@ -6,7 +6,7 @@
 module soulfind.server.messages;
 @safe:
 
-import soulfind.defines : blue, log_msg, norm, RoomTicker;
+import soulfind.defines : blue, log_bytes_rx, log_msg, norm, RoomTicker;
 import soulfind.server.room : Room;
 import soulfind.server.user : User;
 import std.array : Appender;

--- a/src/server/messages.d
+++ b/src/server/messages.d
@@ -13,6 +13,7 @@ import std.array : Appender;
 import std.bitmanip : Endian, nativeToLittleEndian, peek;
 import std.conv : text;
 import std.datetime : days, Duration, SysTime;
+import std.format : format;
 import std.stdio : writeln;
 import std.utf : UTFException, validate;
 
@@ -188,7 +189,8 @@ class UMessage
 
         if (log_msg) writeln(
             "[Msg] Receive <- ", blue, this.name, norm, " (code ", code,
-            ") <- from user ", blue, in_username, norm
+            ") <- from user ", blue, in_username, norm,
+            log_bytes_rx ? " (" ~ format!"%-(%02x %)"(in_buf) ~ ")" : ""
         );
     }
 

--- a/src/server/package.d
+++ b/src/server/package.d
@@ -7,8 +7,8 @@ module soulfind.server;
 @safe:
 
 import soulfind.cli : CommandOption, parse_args, print_help, print_version;
-import soulfind.defines : default_db_filename, exit_message, log_conn, log_db,
-                          log_msg;
+import soulfind.defines : default_db_filename, exit_message, log_bytes_rx,
+                          log_conn, log_db, log_msg;
 import soulfind.server.server : Server;
 import std.conv : text, to;
 import std.stdio : writeln;

--- a/src/server/package.d
+++ b/src/server/package.d
@@ -18,6 +18,7 @@ int run(string[] args)
     string  db_filename = default_db_filename;
     ushort  port;
     bool    enable_debug;
+    bool    enable_debug_rx_bytes;
     bool    show_version;
     bool    show_help;
 
@@ -35,6 +36,10 @@ int run(string[] args)
         CommandOption(
             "", "debug", "Enable debug logging.", null,
             (_) { enable_debug = true; }
+        ),
+        CommandOption(
+            "", "rx-bytes", "Enable debug logging of received bytes.", null,
+            (_) { enable_debug_rx_bytes = true; }
         ),
         CommandOption(
             "v", "version", "Show version.", null,
@@ -64,6 +69,15 @@ int run(string[] args)
     }
 
     if (enable_debug) log_db = log_conn = log_msg = true;
+
+    if (enable_debug_rx_bytes) {
+        if (!enable_debug) {
+            writeln("Warning: '--rx-bytes' flag requires '--debug'");
+        }
+        else {
+            log_bytes_rx = true;
+        }
+    }
 
     auto server = new Server(db_filename);
     const success = server.listen(port);


### PR DESCRIPTION
I wanted to definitively prove that slskd/Soulseek.NET is sending the expected bytes for a message and this was the best way I can think of to do it.  To avoid opting everyone wanting `--debug` in to the logging of raw message bytes, I added the `--rx-bytes` that works in conjunction with `--debug` (and does nothing but log a warning unless both are supplied).

Example output:

```bash
$ ./bin/soulfind --debug --rx-bytes
[DB] Using database: /home/jp/src/soulfind-fork/soulfind.db
[DB] Checking database integrity
[DB] Database integrity verified
[DB] Updated config value port to 2242
[DB] Updated config value max_users to 100000
[DB] Updated config value private_mode to 0
[DB] Updated config value motd to Soulfind %sversion%
♥ Soulfind Mar-25-2026 process 547657 listening on port 2242
[Conn] Connection attempt accepted
[Conn] Registered connection socket
[Msg] Receive <- ULogin (code 1) <- from user [ unknown ] (01 00 00 00 09 00 00 00 70 ... <truncated>)

```

I used AI to help with the `writeln` syntax  in messages.d.