### PR TITLE
db.d: always check integrity and raise on failure

### DIFF
--- a/src/db.d
+++ b/src/db.d
@@ -125,7 +125,7 @@ final class Database
         query("PRAGMA page_size = 4096;");
         query("PRAGMA wal_autocheckpoint = 5000;");
 
-        if (log_db) check_integrity();
+        check_integrity();
 
         enum users_table_sql = text(
             "CREATE TABLE IF NOT EXISTS ", users_table,
@@ -226,14 +226,16 @@ final class Database
 
     private void check_integrity()
     {
-        auto integrity_success = true;
-        writeln("[DB] Checking database integrity");
+        bool integrity_success;
+        if (log_db) writeln("[DB] Checking database integrity");
 
         foreach (ref record ; query("PRAGMA integrity_check;")) {
             const result = record[0];
-            if (result == "ok")
+            if (result == "ok") {
+                integrity_success = true;
+                if (log_db) writeln("[DB] Integrity check result: ", result);
                 continue;
-
+            }
             integrity_success = false;
             writeln("[DB] Integrity issue detected: ", result);
         }
@@ -242,7 +244,7 @@ final class Database
             writeln("[DB] Foreign key issue detected: ", record.join(", "));
         }
 
-        if (integrity_success) writeln("[DB] Database integrity verified");
+        if (!integrity_success) raise_sql_error();
     }
 
 


### PR DESCRIPTION
+ Fixed: Always check integrity even when debug logging is disabled
+ Changed: Always show detected integrity issues even when debug logging is disabled
+ Changed: Only succeed if the "ok" record is retrieved
+ Added: Raise on failure to throw SQLite error

Rather than continuing to create tables and run more queries on a corrupt database, it is better to crash here.