### PR TITLE
pwhash.d: allow Login on single-core CPUs

### DIFF
--- a/src/pwhash.d
+++ b/src/pwhash.d
@@ -133,7 +133,7 @@ void process_password_tasks()
     Appender!(VerifyCallback[])  verify_password_tasks_to_remove;
 
     foreach (ref callback, ref task ; hash_password_tasks) {
-        if (!task.done)
+        if (taskPool.size > 0 && !task.done)
             continue;
 
         auto result = task.yieldForce;
@@ -144,7 +144,7 @@ void process_password_tasks()
         hash_password_tasks.remove(callback);
 
     foreach (ref callback, ref task ; verify_password_tasks) {
-        if (!task.done)
+        if (taskPool.size > 0 && !task.done)
             continue;
 
         auto result = task.yieldForce;

--- a/src/pwhash.d
+++ b/src/pwhash.d
@@ -132,8 +132,13 @@ void process_password_tasks()
     Appender!(HashCallback[])    hash_password_tasks_to_remove;
     Appender!(VerifyCallback[])  verify_password_tasks_to_remove;
 
+    if (taskPool.size == 0)
+        // totalCPUs == 1 single-core (taskPool.size is usually totalCPUs-1)
+        // One task per call forced because worker threads are non-existant
+        force_password_task();
+
     foreach (ref callback, ref task ; hash_password_tasks) {
-        if (taskPool.size > 0 && !task.done)
+        if (!task.done)
             continue;
 
         auto result = task.yieldForce;
@@ -144,7 +149,7 @@ void process_password_tasks()
         hash_password_tasks.remove(callback);
 
     foreach (ref callback, ref task ; verify_password_tasks) {
-        if (taskPool.size > 0 && !task.done)
+        if (!task.done)
             continue;
 
         auto result = task.yieldForce;
@@ -153,6 +158,17 @@ void process_password_tasks()
     }
     foreach (ref callback ; verify_password_tasks_to_remove)
         verify_password_tasks.remove(callback);
+}
+
+private void force_password_task()
+{
+    // Existing accounts always take higher priority
+    if (verify_password_tasks.length > 0)
+        verify_password_tasks.byKeyValue.front.value.yieldForce;
+
+    // New registrations and password changes may take longer
+    else if (hash_password_tasks.length > 0)
+        hash_password_tasks.byKeyValue.front.value.yieldForce;
 }
 
 


### PR DESCRIPTION
+ Fixed: Tasks run synchronously on single-core machines so we must force execute a task from the queue otherwise all logins always timeout and never succeed because each `done` doesn't ever become `true` by itself in the background like what normally happens on multi-core machines.

+ Added: Gracefully degrade on a single-core CPU deployment to one password task per iteration to keep listening if no worker threads, rather than trying to deal with a surge of logins all in one go for so long that everyone gets timed out, otherwise connections could be unable reestablish due to falling into an self-perpetuating timeout/reconnect loop.

`taskPool.size` is equal to `defaultPoolThreads` which is usually `totalCPUs` minus `1`, so if you only have one CPU core then there will be zero thread workers. In that unfortunate runtime environment, the main and only thread has to run all tasks because there are no worker threads, so the only way a task can be `done` is for the calling thread itself to execute it.

Multi-core behaviour is unchanged, this PR only covers the edge case where `taskPool.size` is set to `0` at startup...

```
$ bin/soulfind --debug
[DB] Using SQLite 3.40.1
[DB] Using database: /home/user/Git/soulfind-dev/soulfind/soulfind.db
[DB] Checking database integrity
[DB] Database integrity verified
♥ Soulfind Aug-13-2026 process 3955007 listening on port 2242
[Conn] Connection attempt accepted
[Conn] Registered connection socket
[Msg] Receive <- ULogin (code 1) <- from user [ unknown ]
[Conn] Closing connection to user looks
[Conn] Unregistered and closed connection socket
[Conn] Connection attempt accepted
[Conn] Registered connection socket
[Msg] Receive <- ULogin (code 1) <- from user [ unknown ]
[Conn] Closing connection to user looks
[Conn] Unregistered and closed connection socket
[Conn] Connection attempt accepted
[Conn] Registered connection socket
[Msg] Receive <- ULogin (code 1) <- from user [ unknown ]
[Conn] Closing connection to user looks
[Conn] Unregistered and closed connection socket
```
... Login was impossible because `task.done` could never become `true` in the synchronous runtime case.