### PR TITLE
pwhash.d: avoid hashing expired login attempts

### DIFF
--- a/src/pwhash.d
+++ b/src/pwhash.d
@@ -5,6 +5,7 @@
 module soulfind.pwhash;
 @safe:
 
+import core.atomic : atomicLoad;
 import std.algorithm.iteration : splitter;
 import std.array : Appender;
 import std.bitmanip : nativeToBigEndian;
@@ -16,11 +17,13 @@ import std.parallelism : Task, task, taskPool;
 import std.random : unpredictableSeed;
 import std.string : split;
 
-private alias HashTask    = Task!(hash_password_task, string, string, uint)*;
-private alias VerifyTask  = Task!(verify_password_task, string, string)*;
-
 private alias HashCallback    = void delegate(string, string);
+private alias HashTask        = Task!(hash_password_task, string, string, uint,
+                                      shared(bool)*)*;
+
 private alias VerifyCallback  = void delegate(string, bool, uint);
+private alias VerifyTask      = Task!(verify_password_task, string, string,
+                                      shared(bool)*)*;
 
 private HashTask[HashCallback]      hash_password_tasks;
 private VerifyTask[VerifyCallback]  verify_password_tasks;
@@ -72,9 +75,11 @@ string hash_password(string password, string salt, uint iterations)
 }
 
 void hash_password_async(string password, string salt, uint iterations,
-                         HashCallback callback)
+                         HashCallback callback, shared(bool)* disconnecting)
 {
-    auto task = task!hash_password_task(password, salt, iterations);
+    auto task = task!hash_password_task(
+        password, salt, iterations, disconnecting
+    );
     taskPool.put(task);
     hash_password_tasks[callback] = task;
 }
@@ -120,9 +125,10 @@ VerifyPasswordResult verify_password(string hash, string password)
 }
 
 void verify_password_async(string hash, string password,
-                           VerifyCallback callback)
+                           VerifyCallback callback,
+                           shared(bool)* disconnecting)
 {
-    auto task = task!verify_password_task(hash, password);
+    auto task = task!verify_password_task(hash, password, disconnecting);
     taskPool.put(task);
     verify_password_tasks[callback] = task;
 }
@@ -166,14 +172,22 @@ private struct TaskResult
     uint    iterations;
 }
 
-TaskResult hash_password_task(string password, string salt, uint iterations)
+TaskResult hash_password_task(string password, string salt, uint iterations,
+                              shared(bool)* disconnecting)
 {
+    if (atomicLoad(*disconnecting))
+        return TaskResult();  // Registration abandoned
+
     const hash = hash_password(password, salt, iterations);
     return TaskResult(hash, password);
 }
 
-TaskResult verify_password_task(string hash, string password)
+TaskResult verify_password_task(string hash, string password,
+                                shared(bool)* disconnecting)
 {
+    if (atomicLoad(*disconnecting))
+        return TaskResult();  // Login abandoned
+
     const result = verify_password(hash, password);
     return TaskResult(hash, password, result.matches, result.iterations);
 }

--- a/src/server/msghandler.d
+++ b/src/server/msghandler.d
@@ -695,7 +695,8 @@ final class MessageHandler
             user.hashing_password = true;
             const salt = create_salt();
             hash_password_async(
-                msg.password, salt, pbkdf2_iterations, &user.password_hashed
+                msg.password, salt, pbkdf2_iterations,
+                &user.password_hashed, &user.disconnecting
             );
             break;
 

--- a/src/server/user.d
+++ b/src/server/user.d
@@ -6,6 +6,7 @@
 module soulfind.server.user;
 @safe:
 
+import core.atomic : atomicStore;
 import soulfind.defines : blue, bold, login_timeout, max_interest_length,
                           max_room_name_length, max_user_interests,
                           max_username_length, norm,
@@ -42,6 +43,7 @@ final class User
     UserStatus              status;
     bool                    hashing_password;
     bool                    authenticated;
+    shared bool             disconnecting;      // shared due to pwhash threads
 
     uint                    upload_speed;       // in B/s
     uint                    upload_slots_full;  // unused in clients
@@ -54,7 +56,6 @@ final class User
     private UserConnection  conn;
     private LoginRejection  login_rejection;
     private MonoTime        last_state_refresh;
-    private bool            disconnecting;
 
     private bool[string]    liked_items;
     private bool[string]    hated_items;
@@ -144,18 +145,22 @@ final class User
             return;
         }
 
+        hashing_password = true;
+
         if (!user_exists) {
-            hashing_password = true;
             const salt = create_salt();
             hash_password_async(
-                password, salt, pbkdf2_iterations, &password_hashed
+                password, salt, pbkdf2_iterations,
+                &password_hashed, &disconnecting
             );
             return;
         }
 
-        hashing_password = true;
         const stored_hash = server.db.user_password_hash(username);
-        verify_password_async(stored_hash, password, &password_verified);
+        verify_password_async(
+            stored_hash, password,
+            &password_verified, &disconnecting
+        );
     }
 
     void password_hashed(string password, string hash)
@@ -209,7 +214,8 @@ final class User
             hashing_password = true;
             const salt = create_salt();
             hash_password_async(
-                password, salt, pbkdf2_iterations, &password_upgraded
+                password, salt, pbkdf2_iterations,
+                &password_upgraded, &disconnecting
             );
         }
     }
@@ -234,7 +240,7 @@ final class User
                 writeln("User ", red, username, norm, " logged out");
             }
         }
-        disconnecting = true;
+        atomicStore(disconnecting, true);  // atomic due to pwhash threads
 
         if (relogged) {
             scope relogged_msg = new SRelogged();
@@ -358,7 +364,7 @@ final class User
             server.db.admin_until(username) > Clock.currTime ?
             "Admin " : "User ", blue, username, norm,
             " logged in with client version ", bold, client_version.toString,
-            norm
+            norm, " (", MonoTime.currTime - conn.created_monotime, ")"
         );
 
         server.add_user(this);


### PR DESCRIPTION
+ Added: Atomically store and load the shared `&disconnecting` flag so as to avoid password tasks from doing wasted work
+ Added: Display the total waiting time for each user "logged in" measured since `conn.created_at` until `finish_login()`

Assuming a hash takes 0.250 secs x 10000 logins after server outage cause ~45 mins of work divided by 3 cores = ~15 mins to clear the mostly expired task queue from the first timeout wave at 12 tasks per second, plus the second order waves of timeouts, and so on, resulting in taking several hours until all users are finally logged in due to a vast majority of that work was being spent on fruitlessly hashing many rounds of timed out attempts, since 9280 users are guaranteed to reach the first `login_timeout` and they will try to automatically reconnect multiple times per minute then every 5 minutes thereafter. Most wasted work accumulates into the pool at the surge outset, with old tasks still hashing from the initial early retries, hours after clients exponentially back off.

Whereas sharing the `&disconnecting` flag as such now means any queued task older than ~75 seconds is not executed, so all 10000 users can login within ~15 minutes as expected in about 5 rounds, as such a machine is freed up to process its full capacity of ~720 logins per minute by using all cores productively, i.e. on only the surviving tasks left from each timed out user check.